### PR TITLE
Fixed bug in Variation Parser:

### DIFF
--- a/cellbase-build/src/main/java/org/opencb/cellbase/build/transform/VariationParser.java
+++ b/cellbase-build/src/main/java/org/opencb/cellbase/build/transform/VariationParser.java
@@ -146,7 +146,7 @@ public class VariationParser extends CellBaseParser {
 
                     // Preparing displayConsequenceType and consequenceTypes attributes
                     consequenceTypes = (variationFeatureFields != null) ? Arrays.asList(variationFeatureFields[12].split(",")): Arrays.asList("intergenic_variant");
-                    if(consequenceTypes.size() == 0) {
+                    if(consequenceTypes.size() == 1) {
                         displayConsequenceType = consequenceTypes.get(0);
                     }else {
                         for(String cons: consequenceTypes) {


### PR DESCRIPTION
 when variation has only one consequence type that is 'intergenic_variant' displayConsequenceType is not set