### PR TITLE
ClinVarParser: obtain chromosome directly from 'sequenceLocation' atribute

### DIFF
--- a/cellbase-app/src/main/java/org/opencb/cellbase/app/transform/ClinVarParser.java
+++ b/cellbase-app/src/main/java/org/opencb/cellbase/app/transform/ClinVarParser.java
@@ -75,7 +75,8 @@ public class ClinVarParser extends CellBaseParser{
         ClinvarPublicSet clinvarPublicSet = null;
         SequenceLocationType sequenceLocation = obtainAssembly37SequenceLocation(publicSet);
         if (sequenceLocation != null) {
-            clinvarPublicSet = new ClinvarPublicSet(new RefseqAccession(sequenceLocation.getAccession()).getChromosome(),
+
+            clinvarPublicSet = new ClinvarPublicSet(sequenceLocation.getChr(),
                     sequenceLocation.getStart().intValue(),
                     sequenceLocation.getStop().intValue(),
                     sequenceLocation.getReferenceAllele(),


### PR DESCRIPTION
Some clinvar records don't have 'accession' attribute in the 'SequenceLocation' tab. 'chr' attribute  is always present, so we are going to use that.