### PR TITLE
cli: improve help message for load command

### DIFF
--- a/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/CliOptionsParser.java
+++ b/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/CliOptionsParser.java
@@ -187,7 +187,9 @@ public class CliOptionsParser {
         public CommonCommandOptions commonOptions = commonCommandOptions;
 
 
-        @Parameter(names = {"-d", "--data"}, description = "Data model type to be loaded, i.e. genome, gene, ...", required = true, arity = 1)
+        @Parameter(names = {"-d", "--data"}, description = "Comma separated list of data to load: genome, genome_info, "
+                + "gene, variation, variation_functional_score, regulation, protein, ppi, conservation, drug, "
+                + "clinical_variants, repeats, svs. 'all' loads everything.", required = true, arity = 1)
         public String data;
 
         @Parameter(names = {"-i", "--input"}, description = "Input directory with the JSON data models to be loaded. Can also be used to specify a" +


### PR DESCRIPTION
Had to track down the name of the data models for for loading, [the docs](http://docs.opencb.org/display/cellbase/Building+the+CellBase+database) state that there is a `clinical` collection but it is actually called `clinical_variants`.

- [X] Add a help message for `load` that mirrors the usage of `--data` in the `download` and `build` commands. 