### PR TITLE
Add ability to filter to variant annotation

### DIFF
--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.5</version>
+        <version>4.9.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.6-SNAPSHOT</version>
+        <version>4.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/CliOptionsParser.java
+++ b/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/CliOptionsParser.java
@@ -447,6 +447,10 @@ public class CliOptionsParser {
                 arity = 0)
         public boolean checkAminoAcidChange;
 
+        @Parameter(names = {"--filter"}, description = "string indicating the FILTER label that variants must have to be annotated. "
+                + "Only variants with this label will be written in the output.", required = false, arity = 1)
+        public String filter = null;
+
         @DynamicParameter(names = "-D", description = "Dynamic parameters. Available parameters: "
                 + "{population-frequencies=for internal purposes mainly. Full path to a json file containing Variant "
                 + "documents that include lists of population frequencies objects. Will allow annotating the input file "

--- a/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/VariantAnnotationCommandExecutor.java
+++ b/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/VariantAnnotationCommandExecutor.java
@@ -392,7 +392,7 @@ public class VariantAnnotationCommandExecutor extends CommandExecutor {
 
         for (int i = 0; i < numThreads; i++) {
             List<VariantAnnotator> variantAnnotatorList = createAnnotators();
-            variantAnnotatorTaskList.add(new VariantAnnotatorTask(variantAnnotatorList));
+            variantAnnotatorTaskList.add(new VariantAnnotatorTask(variantAnnotatorList, serverQueryOptions));
         }
         return variantAnnotatorTaskList;
     }
@@ -573,7 +573,7 @@ public class VariantAnnotationCommandExecutor extends CommandExecutor {
         leftAlign = !variantAnnotationCommandOptions.skipLeftAlign;
         // Update serverQueryOptions
         serverQueryOptions.put("checkAminoAcidChange", variantAnnotationCommandOptions.checkAminoAcidChange);
-
+        serverQueryOptions.put("filter", variantAnnotationCommandOptions.filter);
         // output file
         if (variantAnnotationCommandOptions.output != null) {
             output = Paths.get(variantAnnotationCommandOptions.output);

--- a/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/variant/annotation/VariantAnnotatorTask.java
+++ b/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/variant/annotation/VariantAnnotatorTask.java
@@ -1,14 +1,17 @@
 package org.opencb.cellbase.app.cli.variant.annotation;
 
 import org.opencb.biodata.models.variant.Variant;
+import org.opencb.biodata.models.variant.avro.FileEntry;
 import org.opencb.biodata.models.variant.avro.VariantType;
 import org.opencb.cellbase.core.variant.annotation.VariantAnnotator;
+import org.opencb.commons.datastore.core.QueryOptions;
 import org.opencb.commons.run.ParallelTaskRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by fjlopez on 11/02/16.
@@ -18,9 +21,16 @@ public class VariantAnnotatorTask implements
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private List<VariantAnnotator> variantAnnotatorList;
+    private QueryOptions serverQueryOptions;
+    private static final String FILTER_PARAM = "filter";
 
     public VariantAnnotatorTask(List<VariantAnnotator> variantAnnotatorList) {
+        this(variantAnnotatorList, new QueryOptions());
+    }
+
+    public VariantAnnotatorTask(List<VariantAnnotator> variantAnnotatorList, QueryOptions serverQueryOptions) {
         this.variantAnnotatorList = variantAnnotatorList;
+        this.serverQueryOptions = serverQueryOptions;
     }
 
     public void pre() {
@@ -30,16 +40,39 @@ public class VariantAnnotatorTask implements
     }
 
     public List<Variant> apply(List<Variant> batch) throws Exception {
-        List<Variant> variantListToAnnotate = filterReferenceBlocksOut(batch);
+        List<Variant> variantListToAnnotate = filter(batch);
         for (VariantAnnotator variantAnnotator : variantAnnotatorList) {
             variantAnnotator.run(variantListToAnnotate);
         }
         return variantListToAnnotate;
     }
 
-    private List<Variant> filterReferenceBlocksOut(List<Variant> variantList) {
+    private List<Variant> filter(List<Variant> variantList) {
         List<Variant> filteredVariantList = new ArrayList<>(variantList.size());
+        String filterValue = null;
+        if (serverQueryOptions != null && serverQueryOptions.containsKey(FILTER_PARAM)) {
+            filterValue = (String) serverQueryOptions.get(FILTER_PARAM);
+        }
         for (Variant variant : variantList) {
+            // if filter set, VCF line must match or skip
+            if (filterValue != null) {
+                boolean filterMatch = true;
+                List<org.opencb.biodata.models.variant.avro.StudyEntry> studyEntryList = variant.getImpl().getStudies();
+                for (org.opencb.biodata.models.variant.avro.StudyEntry studyEntry : studyEntryList) {
+                    FileEntry fileEntry = studyEntry.getFiles().get(0);
+                    Map<String, String> attributes = fileEntry.getAttributes();
+                    String filterVcfValue = attributes.get("FILTER");
+                    if (!filterVcfValue.equalsIgnoreCase(filterValue)) {
+                        // filter is set but there is no match. skip.
+                        filterMatch = false;
+                    }
+                }
+                if (!filterMatch) {
+                    // filter is set but there is no match. skip.
+                    continue;
+                }
+            }
+            // filter out reference blocks
             if (!VariantType.NO_VARIATION.equals(variant.getType())) {
                 filteredVariantList.add(variant);
             }

--- a/cellbase-app/src/test/java/org/opencb/cellbase/app/cli/VariantAnnotationCommandExecutorTest.java
+++ b/cellbase-app/src/test/java/org/opencb/cellbase/app/cli/VariantAnnotationCommandExecutorTest.java
@@ -45,6 +45,7 @@ public class VariantAnnotationCommandExecutorTest {
         jsonObjectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
     }
 
+
     @Test
     public void proteinChangeMatchTest() throws IOException, URISyntaxException {
         // Remove database content
@@ -123,7 +124,7 @@ public class VariantAnnotationCommandExecutorTest {
                 "FAKEATTRIBUTE",
                 null,
                 null,
-                -1
+                -1, null
         ));
         variantAnnotationCommandExecutor.loadCellBaseConfiguration();
         variantAnnotationCommandExecutor.execute();
@@ -156,7 +157,7 @@ public class VariantAnnotationCommandExecutorTest {
                 "GN,AF,AC,AN,MAF,HWE,AN_Cancer,AN_SRv3,AN_RD,AN_SRv4,AC_Cancer,AC_SRv3,AC_RD,AC_SRv4,AF_Cancer,AF_SRv3,AF_RD,AF_SRv4,MAF_Cancer,MAF_SRv3,MAF_RD,MAF_SRv4,HWE_Cancer,HWE_SRv3,HWE_RD,HWE_SRv4:GN,AF,AC,AN,MAF,HWE,AN_Cancer,AN_SRv3,AN_RD,AN_SRv4,AC_Cancer,AC_SRv3,AC_RD,AC_SRv4,AF_Cancer,AF_SRv3,AF_RD,AF_SRv4,MAF_Cancer,MAF_SRv3,MAF_RD,MAF_SRv4,HWE_Cancer,HWE_SRv3,HWE_RD,HWE_SRv4",
                 null,
                 null,
-                100
+                100, null
         ));
         variantAnnotationCommandExecutor.loadCellBaseConfiguration();
 
@@ -201,7 +202,7 @@ public class VariantAnnotationCommandExecutorTest {
                 "GN,AF,AC,AN,MAF,HWE,AN_Cancer,AN_SRv3,AN_RD,AN_SRv4,AC_Cancer,AC_SRv3,AC_RD,AC_SRv4,AF_Cancer,AF_SRv3,AF_RD,AF_SRv4,MAF_Cancer,MAF_SRv3,MAF_RD,MAF_SRv4,HWE_Cancer,HWE_SRv3,HWE_RD,HWE_SRv4",
                 null,
                 null,
-                100
+                100, null
         ));
         variantAnnotationCommandExecutor.loadCellBaseConfiguration();
 
@@ -244,7 +245,7 @@ public class VariantAnnotationCommandExecutorTest {
                 "GN,AF,AC,AN,MAF,HWE,AN_Cancer,AN_SRv3,AN_RD,AN_SRv4,AC_Cancer,AC_SRv3,AC_RD,AC_SRv4,AF_Cancer,AF_SRv3,AF_RD,AF_SRv4,MAF_Cancer,MAF_SRv3,MAF_RD,MAF_SRv4,HWE_Cancer,HWE_SRv3,HWE_RD,HWE_SRv4",
                 null,
                 null,
-                100
+                100, null
                 ));
         variantAnnotationCommandExecutor.loadCellBaseConfiguration();
         variantAnnotationCommandExecutor.execute();
@@ -323,7 +324,7 @@ public class VariantAnnotationCommandExecutorTest {
                 "GN,AF,AC,AN,MAF,HWE,AN_Cancer,AN_SRv3,AN_RD,AN_SRv4,AC_Cancer,AC_SRv3,AC_RD,AC_SRv4,AF_Cancer,AF_SRv3,AF_RD,AF_SRv4,MAF_Cancer,MAF_SRv3,MAF_RD,MAF_SRv4,HWE_Cancer,HWE_SRv3,HWE_RD,HWE_SRv4",
                 null,
                 null,
-                -1
+                -1, null
                 ));
         variantAnnotationCommandExecutor.loadCellBaseConfiguration();
         variantAnnotationCommandExecutor.execute();
@@ -383,7 +384,7 @@ public class VariantAnnotationCommandExecutorTest {
                         .resolve("commandExecutor/additionalPopulationFrequency/chr1.2017-12-27_01_12.hgva.freq.cellbase.test.json.gz")
                         .toString(),
                 true,
-                -1
+                -1, null
                 ));
         variantAnnotationCommandExecutor.loadCellBaseConfiguration();
         variantAnnotationCommandExecutor.execute();
@@ -481,6 +482,9 @@ public class VariantAnnotationCommandExecutorTest {
 
     }
 
+
+
+
     @Test
     public void additionalPopulationFrequencyPhasedAnnotationTest() throws Exception {
         cleanUp();
@@ -495,7 +499,7 @@ public class VariantAnnotationCommandExecutorTest {
                         .resolve("commandExecutor/additionalPopulationFrequency/chr1.2017-12-27_01_12.hgva.freq.cellbase.test.json.gz")
                         .toString(),
                 true,
-                -1));
+                -1, null));
         variantAnnotationCommandExecutor.loadCellBaseConfiguration();
         variantAnnotationCommandExecutor.execute();
         List<Variant> variantList = loadResult();
@@ -725,6 +729,52 @@ public class VariantAnnotationCommandExecutorTest {
 
     }
 
+
+    @Test
+    public void testFilter() throws Exception {
+        cleanUp();
+
+        // Set up annotation CLI options: NOTE checkAminoAcidChange is NOT enabled
+        CliOptionsParser.VariantAnnotationCommandOptions variantAnnotationCommandOptions
+                = new CliOptionsParser().getVariantAnnotationCommandOptions();
+        variantAnnotationCommandOptions.assembly = "GRCh37";
+        variantAnnotationCommandOptions.commonOptions.conf = resourcesFolder.resolve("commandExecutor/configuration.json").toString();
+        variantAnnotationCommandOptions.input
+                = resourcesFolder.resolve("commandExecutor/proteinChangeMatch/proband.duprem.atomic.left.split.vcf.gz").toString();
+        variantAnnotationCommandOptions.output = OUTPUT_FILENAME;
+        variantAnnotationCommandOptions.local = true;
+        variantAnnotationCommandOptions.species = "hsapiens";
+        variantAnnotationCommandOptions.filter = "PASS";
+        // Annotate
+        VariantAnnotationCommandExecutor variantAnnotationCommandExecutor
+                = new VariantAnnotationCommandExecutor(variantAnnotationCommandOptions);
+        variantAnnotationCommandExecutor.loadCellBaseConfiguration();
+        variantAnnotationCommandExecutor.execute();
+        // Load annotated variants
+        List<Variant> variantList = loadResult();
+
+        // one variant has the PASS filter
+        assertEquals(1, variantList.size());
+
+        variantAnnotationCommandOptions.filter = "BAD FILTER";
+        variantAnnotationCommandExecutor = new VariantAnnotationCommandExecutor(variantAnnotationCommandOptions);
+        variantAnnotationCommandExecutor.loadCellBaseConfiguration();
+        variantAnnotationCommandExecutor.execute();
+        variantList = loadResult();
+
+        // one variant has the PASS filter. there should be no results!
+        assertEquals(0, variantList.size());
+
+        variantAnnotationCommandOptions.filter = null;
+        variantAnnotationCommandExecutor = new VariantAnnotationCommandExecutor(variantAnnotationCommandOptions);
+        variantAnnotationCommandExecutor.loadCellBaseConfiguration();
+        variantAnnotationCommandExecutor.execute();
+        variantList = loadResult();
+
+        // no filter 1 results
+        assertEquals(1, variantList.size());
+    }
+
     private List<PopulationFrequency> getPopulationFrequency(List<PopulationFrequency> populationFrequencyList,
                                                              PopulationFrequency populationFrequency) {
         List<PopulationFrequency> populationFrequencyList1 = new ArrayList<>(1);
@@ -800,7 +850,8 @@ public class VariantAnnotationCommandExecutorTest {
                                        String customFileFields,
                                        String populationFrequencyFilename,
                                        Boolean completeInputPopulation,
-                                       int maxOpenFiles) {
+                                       int maxOpenFiles,
+                                       String filter) {
 
         CliOptionsParser.VariantAnnotationCommandOptions variantAnnotationCommandOptions
                 = new CliOptionsParser().getVariantAnnotationCommandOptions();
@@ -828,6 +879,7 @@ public class VariantAnnotationCommandExecutorTest {
         variantAnnotationCommandOptions.maxOpenFiles = maxOpenFiles;
         variantAnnotationCommandOptions.noImprecision = true;
         variantAnnotationCommandOptions.buildParams = (new HashMap<>(1));
+        variantAnnotationCommandOptions.filter = filter;
 
         if (populationFrequencyFilename != null) {
             variantAnnotationCommandOptions.buildParams.put("population-frequencies", populationFrequencyFilename);

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.5</version>
+        <version>4.9.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.6-SNAPSHOT</version>
+        <version>4.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.5</version>
+        <version>4.9.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.6-SNAPSHOT</version>
+        <version>4.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.5</version>
+        <version>4.9.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.6-SNAPSHOT</version>
+        <version>4.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.5</version>
+        <version>4.9.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.6-SNAPSHOT</version>
+        <version>4.10.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.9.5</version>
+    <version>4.9.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.9.6-SNAPSHOT</version>
+    <version>4.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.9.5</version>
+    <version>4.9.6-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.9.5</cellbase.version>
+        <cellbase.version>4.9.6-SNAPSHOT</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.5</biodata.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.9.6-SNAPSHOT</version>
+    <version>4.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.9.6-SNAPSHOT</cellbase.version>
+        <cellbase.version>4.10.0-SNAPSHOT</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.5</biodata.version>


### PR DESCRIPTION
Added a parameter to variant-annotation to filter on the FILTER column in VCF files:
```
      --filter                     STRING        string indicating the FILTER label that variants must have to be annotated. Only variants with this label will be written in the output.
```
