### PR TITLE
merge v4.9.x fixes into v5

### DIFF
--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/ClinVarIndexer.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/ClinVarIndexer.java
@@ -837,6 +837,9 @@ public class ClinVarIndexer extends ClinicalIndexer {
         if (emptySequence(reference) && !emptySequence(alternate) && end == (start + 1)) {
             // NOTE! swapped start and end
             return new SequenceLocation(chromosome, end, start, reference, alternate);
+        } else if (alternate.length() == 1 && reference.length() > 1 && reference.startsWith(alternate)) {
+            // variant summary file has the wrong location for deletions. Adjust!
+            return new SequenceLocation(chromosome, start - 1, end, reference, alternate);
         } else {
             return new SequenceLocation(chromosome, start, end, reference, alternate);
         }

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/ConsequenceTypeGenericRegionCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/ConsequenceTypeGenericRegionCalculator.java
@@ -474,46 +474,26 @@ public class ConsequenceTypeGenericRegionCalculator extends ConsequenceTypeCalcu
         }
 
         if (regionsOverlap(spliceSite1, spliceSite1 + 1, variantStart, variantEnd)) {  // Variant donor/acceptor
-            if ((variantEnd - variantStart) <= BIG_VARIANT_SIZE_THRESHOLD) {  // Big cnvs should not be annotated with such a detail
-                SoNames.add(leftSpliceSiteTag);  // donor/acceptor depending on transcript strand
-                // BE CAREFUL: there are introns shorter than 7nts, and even just 1nt long!! (22:36587846)
-                junctionSolution[0] = (variantStart <= spliceSite2 || variantEnd <= spliceSite2);
-            } else {
-                // BE CAREFUL: there are introns shorter than 7nts, and even just 1nt long!! (22:36587846)
-                junctionSolution[0] = (variantStart <= spliceSite2 || variantEnd <= spliceSite2);
-            }
-        } else if (regionsOverlap(spliceSite1 + 2, spliceSite1 + 7, variantStart, variantEnd)) {
-            // Insertion coordinates are passed to this function as (variantStart-1,variantStart)
-            if ((variantEnd - variantStart) <= BIG_VARIANT_SIZE_THRESHOLD) {
-                SoNames.add(VariantAnnotationUtils.SPLICE_REGION_VARIANT);
-            }
+            SoNames.add(leftSpliceSiteTag);  // donor/acceptor depending on transcript strand
             // BE CAREFUL: there are introns shorter than 7nts, and even just 1nt long!! (22:36587846)
             junctionSolution[0] = (variantStart <= spliceSite2 || variantEnd <= spliceSite2);
-        } else if (regionsOverlap(spliceSite1 - 3, spliceSite1 - 1, variantStart, variantEnd)
-                // Insertion coordinates are passed to this function as (variantStart-1,variantStart)
-                && ((variantEnd - variantStart) <= BIG_VARIANT_SIZE_THRESHOLD)) {
+        } else if (regionsOverlap(spliceSite1 + 2, spliceSite1 + 7, variantStart, variantEnd)) {
+            // Insertion coordinates are passed to this function as (variantStart-1,variantStart)
+            SoNames.add(VariantAnnotationUtils.SPLICE_REGION_VARIANT);
+            // BE CAREFUL: there are introns shorter than 7nts, and even just 1nt long!! (22:36587846)
+            junctionSolution[0] = (variantStart <= spliceSite2 || variantEnd <= spliceSite2);
+        } else if (regionsOverlap(spliceSite1 - 3, spliceSite1 - 1, variantStart, variantEnd)) {
             SoNames.add(VariantAnnotationUtils.SPLICE_REGION_VARIANT);
         }
 
         if (regionsOverlap(spliceSite2 - 1, spliceSite2, variantStart, variantEnd)) {  // Variant donor/acceptor
-            if ((variantEnd - variantStart) <= BIG_VARIANT_SIZE_THRESHOLD) {  // Big cnvs should not be annotated with such a detail
-                SoNames.add(rightSpliceSiteTag);  // donor/acceptor depending on transcript strand
-                // BE CAREFUL: there are introns shorter than 7nts, and even just 1nt long!! (22:36587846)
-                junctionSolution[0] = (spliceSite1 <= variantStart || spliceSite1 <= variantEnd);
-            } else {
-                // BE CAREFUL: there are introns shorter than 7nts, and even just 1nt long!! (22:36587846)
-                junctionSolution[0] = (spliceSite1 <= variantStart || spliceSite1 <= variantEnd);
-            }
+            SoNames.add(rightSpliceSiteTag);  // donor/acceptor depending on transcript strand
+            junctionSolution[0] = (spliceSite1 <= variantStart || spliceSite1 <= variantEnd);
         } else if (regionsOverlap(spliceSite2 - 7, spliceSite2 - 2, variantStart, variantEnd)) {
-            // Insertion coordinates are passed to this function as (variantStart-1,variantStart) {
-            if ((variantEnd - variantStart) <= BIG_VARIANT_SIZE_THRESHOLD) {
-                SoNames.add(VariantAnnotationUtils.SPLICE_REGION_VARIANT);
-            }
+            SoNames.add(VariantAnnotationUtils.SPLICE_REGION_VARIANT);
             // BE CAREFUL: there are introns shorter than 7nts, and even just 1nt long!! (22:36587846)
             junctionSolution[0] = (spliceSite1 <= variantStart || spliceSite1 <= variantEnd);
-        } else if (regionsOverlap(spliceSite2 + 1, spliceSite2 + 3, variantStart, variantEnd)
-                // Insertion coordinates are passed to this function as (variantStart-1,variantStart) {
-                && ((variantEnd - variantStart) <= BIG_VARIANT_SIZE_THRESHOLD)) {
+        } else if (regionsOverlap(spliceSite2 + 1, spliceSite2 + 3, variantStart, variantEnd)) {
             SoNames.add(VariantAnnotationUtils.SPLICE_REGION_VARIANT);
         }
     }

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
@@ -1641,9 +1641,7 @@ public class VariantAnnotationCalculator {
                 for (int i = 0; i < variantAnnotationList.size(); i++) {
                     CellBaseDataResult<Variant> clinicalCellBaseDataResult = clinicalCellBaseDataResults.get(i);
                     if (clinicalCellBaseDataResult.getResults() != null && clinicalCellBaseDataResult.getResults().size() > 0) {
-                        variantAnnotationList.get(i)
-                                .setTraitAssociation(clinicalCellBaseDataResult.getResults().get(0).getAnnotation()
-                                        .getTraitAssociation());
+                        variantAnnotationList.get(i).setTraitAssociation(getAllTraitAssociations(clinicalCellBaseDataResult));
 //                        // DEPRECATED
 //                        // TODO: remove in 4.6
 //                        variantAnnotationList.get(i)
@@ -1655,6 +1653,14 @@ public class VariantAnnotationCalculator {
                     }
                 }
             }
+        }
+
+        private List<EvidenceEntry> getAllTraitAssociations(CellBaseDataResult<Variant> clinicalQueryResult) {
+            List<EvidenceEntry> traitAssociations = new ArrayList<>();
+            for (Variant variant: clinicalQueryResult.getResults()) {
+                traitAssociations.addAll(variant.getAnnotation().getTraitAssociation());
+            }
+            return traitAssociations;
         }
 
 //        private VariantTraitAssociation convertToVariantTraitAssociation(List<EvidenceEntry> traitAssociation) {

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
@@ -762,8 +762,14 @@ public class VariantAnnotationCalculator {
                     if (consequenceType3 != null) {
                         String referenceCodon = consequenceType1.getCodon().split("/")[0].toUpperCase();
                         // WARNING: assumes variants are sorted according to their coordinates
-                        String alternateCodon = variant0.getAlternate() + variant1.getAlternate()
-                                + variant2.getAlternate();
+                        String alternateCodon = null;
+                        if ("-".equals(variant0.getStrand())) {
+                            alternateCodon = "" + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant2.getAlternate())
+                                    + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant1.getAlternate())
+                                    + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant0.getAlternate());
+                        } else {
+                            alternateCodon = variant0.getAlternate() + variant1.getAlternate() + variant2.getAlternate();
+                        }
                         codon = referenceCodon + "/" + alternateCodon;
                         alternateAA = VariantAnnotationUtils.CODON_TO_A.get(alternateCodon);
                         soTerms = updatePhasedSoTerms(consequenceType1.getSequenceOntologyTerms(),
@@ -795,8 +801,16 @@ public class VariantAnnotationCalculator {
                         referenceCodonArray[codonIdx1] = Character.toUpperCase(referenceCodonArray[codonIdx1]);
                         referenceCodonArray[codonIdx2] = Character.toUpperCase(referenceCodonArray[codonIdx2]);
                         char[] alternateCodonArray = referenceCodonArray.clone();
-                        alternateCodonArray[codonIdx1] = variant0.getAlternate().toUpperCase().toCharArray()[0];
-                        alternateCodonArray[codonIdx2] = variant1.getAlternate().toUpperCase().toCharArray()[0];
+                        // negative strand
+                        if ("-".equals(variant0.getStrand())) {
+                            alternateCodonArray[codonIdx1] =
+                                    VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant0.getAlternate().toUpperCase().toCharArray()[0]);
+                            alternateCodonArray[codonIdx2] =
+                                    VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant1.getAlternate().toUpperCase().toCharArray()[0]);
+                        } else {
+                            alternateCodonArray[codonIdx1] = variant0.getAlternate().toUpperCase().toCharArray()[0];
+                            alternateCodonArray[codonIdx2] = variant1.getAlternate().toUpperCase().toCharArray()[0];
+                        }
 
                         codon = String.valueOf(referenceCodonArray) + "/" + String.valueOf(alternateCodonArray);
                         alternateAA = VariantAnnotationUtils.CODON_TO_A.get(String.valueOf(alternateCodonArray).toUpperCase());

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
@@ -1094,8 +1094,8 @@ public class VariantAnnotationCalculator {
 
     private List<String> getIncludedGeneFields(Set<String> annotatorSet) {
             List<String> includeGeneFields = new ArrayList<>(Arrays.asList("name", "id", "chromosome", "start", "end", "transcripts.id",
-                "transcripts.proteinId", "transcripts.start", "transcripts.end", "transcripts.cdnaSequence", "transcripts.proteinSequence",
-                "transcripts.strand", "transcripts.cdsLength", "transcripts.flags", "transcripts.biotype",
+                "transcripts.proteinId", "transcripts.chromosome", "transcripts.start", "transcripts.end", "transcripts.cdnaSequence",
+                "transcripts.proteinSequence", "transcripts.strand", "transcripts.cdsLength", "transcripts.flags", "transcripts.biotype",
                 "transcripts.genomicCodingStart", "transcripts.genomicCodingEnd", "transcripts.cdnaCodingStart",
                 "transcripts.cdnaCodingEnd", "transcripts.exons.start", "transcripts.exons.cdsStart", "transcripts.exons.end",
                 "transcripts.exons.cdsEnd", "transcripts.exons.sequence", "transcripts.exons.phase",

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsCalculator.java
@@ -51,6 +51,7 @@ public class HgvsCalculator {
     protected static final int NEIGHBOURING_SEQUENCE_SIZE = 100;
     protected GenomeManager genomeManager;
     protected BuildingComponents buildingComponents;
+    private static final String VARIANT_STRING_PATTERN = "[ACGT]*";
 
     public HgvsCalculator(GenomeManager genomeManager) {
         this.genomeManager = genomeManager;
@@ -119,6 +120,21 @@ public class HgvsCalculator {
             }
         }
         return hgvsStrings;
+    }
+
+    /**
+     * Checks whether a variant is valid.
+     *
+     * @param variant Variant object to be checked.
+     * @return   true/false depending on whether 'variant' does contain valid values. Currently just a simple check of
+     * reference/alternate attributes being strings of [A,C,G,T] of length >= 0 is performed to detect cases such as
+     * 19:13318673:(CAG)4:(CAG)5 which are not currently supported by CellBase. Ref and alt alleles must be different
+     * as well for the variant to be valid. Functionality of the method may be improved in the future.
+     */
+    protected static boolean isValid(Variant variant) {
+        return (variant.getReference().matches(VARIANT_STRING_PATTERN)
+                && variant.getAlternate().matches(VARIANT_STRING_PATTERN)
+                && !variant.getAlternate().equals(variant.getReference()));
     }
 
 //    private HgvsCalculator getHgvsCalculator(Variant normalizedVariant) {

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsCalculator.java
@@ -97,7 +97,8 @@ public class HgvsCalculator {
         List<String> hgvsStrings = new ArrayList<>();
 
         // Check variant falls within transcript coords
-        if (variant.getStart() <= transcript.getEnd() && variant.getEnd() >= transcript.getStart()) {
+        if (variant.getChromosome().equals(transcript.getChromosome())
+                && variant.getStart() <= transcript.getEnd() && variant.getEnd() >= transcript.getStart()) {
             // We cannot know the type of variant before normalization has been carried out
             Variant normalizedVariant = normalize(variant, normalize);
 

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
@@ -300,6 +300,9 @@ public class HgvsProteinCalculator {
                 String refAa = VariantAnnotationUtils.getAminoacid(MT.equals(variant.getChromosome()), refCodon);
 
                 // Build the new inserted sequence = split codon + alternate allele
+                if (refCodon.length() < positionAtCodon) {
+                    return null;
+                }
                 String insSequence = refCodon.substring(0, positionAtCodon - 1) + alternate + refCodon.substring(positionAtCodon - 1);
 
                 // need inserted sequence to be divisible by 3 to predict AAs later
@@ -442,6 +445,9 @@ public class HgvsProteinCalculator {
 
             // keep moving to the right (3' Rule) while the first amino acid deleted equals the first one after deletion,
             // Example: check 11:6390701:-:CTGGCGCTGGCG
+            if (transcript.getProteinSequence().length() < aminoacidPosition) {
+                return null;
+            }
             String aaAfterInsertion = transcript.getProteinSequence().substring(aminoacidPosition - 1, aminoacidPosition);
             while (codedAminoacids.get(0).equals(aaAfterInsertion)) {
                 aminoacidPosition++;
@@ -449,11 +455,17 @@ public class HgvsProteinCalculator {
                 codedAminoacids.remove(0);
                 aminoacids.add(VariantAnnotationUtils.TO_LONG_AA.get(aaAfterInsertion));
                 codedAminoacids.add(aaAfterInsertion);
+                if (aminoacidPosition <= 0 || transcript.getProteinSequence().length() < aminoacidPosition) {
+                    return null;
+                }
                 aaAfterInsertion = transcript.getProteinSequence().substring(aminoacidPosition - 1, aminoacidPosition);
             }
 
             // Get position and flanking amino acids
             int codonIndex = aminoacidPosition - 1;
+            if (codonIndex <= 0 || transcript.getProteinSequence().length() < codonIndex) {
+                return null;
+            }
             String leftCodedAa = transcript.getProteinSequence().substring(codonIndex - 1, codonIndex);
             String leftAa = VariantAnnotationUtils.TO_LONG_AA.get(leftCodedAa);
 
@@ -584,7 +596,7 @@ public class HgvsProteinCalculator {
         if (referenceAllele.length() % 3 == 0) {
             if (positionAtCodon == 1) {
                 // TODO Check is the aminoposition is the STOP codon, this is a HGVS extension, is this a frameshift?
-                if (aminoacidPosition + deletionAaLength > transcript.getProteinSequence().length()) {
+                if (transcript.getProteinSequence().length() <= aminoacidPosition + deletionAaLength) {
                     // Deletion includes STOP codon
                     return null;
                 }
@@ -667,8 +679,15 @@ public class HgvsProteinCalculator {
                 // Get the new codon created after the deletion
                 String firstAffectedCodon = transcriptUtils.getCodon(aminoacidPosition);    // GAC
                 String lastAffectedCodon = transcriptUtils.getCodon(aminoacidPosition + deletionAaLength);  // CGC
-                String newAlternateCodon = firstAffectedCodon.substring(0, positionAtCodon - 1)
-                        + lastAffectedCodon.substring(positionAtCodon - 1); // GA + C = GAC
+                String newAlternateCodon = null;
+                if (positionAtCodon > 0 && StringUtils.isNotEmpty(firstAffectedCodon) && StringUtils.isNotEmpty(lastAffectedCodon)
+                        && firstAffectedCodon.length() >= positionAtCodon && lastAffectedCodon.length() >= positionAtCodon) {
+                    newAlternateCodon = firstAffectedCodon.substring(0, positionAtCodon - 1)
+                            + lastAffectedCodon.substring(positionAtCodon - 1); // GA + C = GAC
+                } else {
+                    logger.info("Couldn't calculate HGVSp for " + variant.getId());
+                    return null;
+                }
 
                 String firstAffectedAa = VariantAnnotationUtils.getAminoacid(MT.equals(variant.getChromosome()), firstAffectedCodon);
                 String lastAffectedAa = VariantAnnotationUtils.getAminoacid(MT.equals(variant.getChromosome()), lastAffectedCodon);
@@ -802,6 +821,11 @@ public class HgvsProteinCalculator {
         }
 
         // Get position and flanking amino acids
+        if (leftAminoAcidPosition < 1 || rightAminoAcidPosition < 1 || transcript.getProteinSequence() == null
+                || transcript.getProteinSequence().length() < leftAminoAcidPosition
+                || transcript.getProteinSequence().length() < rightAminoAcidPosition) {
+            return null;
+        }
         String leftCodedAa = transcript.getProteinSequence().substring(leftAminoAcidPosition - 1, leftAminoAcidPosition);
         String leftAa = VariantAnnotationUtils.TO_LONG_AA.get(leftCodedAa);
         String rightCodedAa = transcript.getProteinSequence().substring(rightAminoAcidPosition - 1, rightAminoAcidPosition);
@@ -944,7 +968,12 @@ public class HgvsProteinCalculator {
                 if (!alternateCodedAa.equals(referenceCodedAa)) {
                     // Keep the first amino acid changed, including a premature STOP codon
                     if (firstDiffIndex == -1) {
-                        firstReferencedAa = StringUtils.capitalize(VariantAnnotationUtils.TO_LONG_AA.get(referenceCodedAa).toLowerCase());
+                        String longAA = VariantAnnotationUtils.TO_LONG_AA.get(referenceCodedAa);
+                        if (StringUtils.isEmpty(longAA)) {
+                            logger.info("Invalid AA found: " + referenceCodedAa + " for variant " + variant.getId());
+                            return null;
+                        }
+                        firstReferencedAa = StringUtils.capitalize(longAA.toLowerCase());
                         firstAlternateAa = StringUtils.capitalize(alternateAa.toLowerCase());
                         firstDiffIndex = currentAaIndex;
 

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
@@ -296,10 +296,17 @@ public class HgvsProteinCalculator {
 
                 // Get the reference codon and the new sequence inserted
                 String refCodon = transcriptUtils.getCodon(codonPosition);
+                String afterRefCodon = transcriptUtils.getCodon(codonPosition);
                 String refAa = VariantAnnotationUtils.getAminoacid(MT.equals(variant.getChromosome()), refCodon);
 
                 // Build the new inserted sequence = split codon + alternate allele
                 String insSequence = refCodon.substring(0, positionAtCodon - 1) + alternate + refCodon.substring(positionAtCodon - 1);
+
+                // need inserted sequence to be divisible by 3 to predict AAs later
+                if (insSequence.length() % 3 > 0) {
+                    // append NTs until sequence has enough codons
+                    insSequence = insSequence + afterRefCodon.substring(0, (3 - insSequence.length() % 3));
+                }
 
                 // Insertion or Duplication need the reference codon to be the same.
                 // Check if the reference codon is at any end of the new inserted sequence.

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
@@ -336,7 +336,7 @@ public class HgvsProteinCalculator {
                 }
 
                 // Check if the the original amino acid is kept
-                if (refAa.equalsIgnoreCase(insertLeftAa) || refAa.equalsIgnoreCase(insertRightAa)) {
+                if (StringUtils.isNotEmpty(refAa) && refAa.equalsIgnoreCase(insertLeftAa) || refAa.equalsIgnoreCase(insertRightAa)) {
                     // Check if the new sequence is inserted left or right to the original reference codon.
                     // Remove the reference codon and update codonPosition for the insertion
                     if (refAa.equalsIgnoreCase(insertLeftAa)) {

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
@@ -55,6 +55,7 @@ public class HgvsProteinCalculator {
     protected BuildingComponents buildingComponents = null;
 
     public static final int MAX_NUMBER_AMINOACIDS_DISPLAYED = 10;
+    private static final Integer MAXIMUM_HGVS_DELETION_LENGTH = 1000;
 
     /**
      * Constructor.
@@ -74,6 +75,10 @@ public class HgvsProteinCalculator {
      * @return HGVSp string for variant and transcript
      */
     public HgvsProtein calculate() {
+        // Check reference and alternate alleles do not contain unexpected characters
+        if (!HgvsCalculator.isValid(this.variant)) {
+            return null;
+        }
         // FIXME  restore !onlySpansCodingSequence(variant, transcript) check
         if (!transcriptUtils.isCoding() || StringUtils.isEmpty(transcript.getProteinSequence())) {
             return null;
@@ -91,7 +96,12 @@ public class HgvsProteinCalculator {
                 } else {
                     // deletion
                     if (StringUtils.isBlank(variant.getAlternate())) {
-                        return calculateDeletionHgvs();
+                        // Only for deletions shorter than a threshold
+                        if (variant.getLength() < MAXIMUM_HGVS_DELETION_LENGTH) {
+                            return calculateDeletionHgvs();
+                        } else {
+                            return null;
+                        }
                     } else {
                         logger.debug("No HGVS implementation available for variant MNV. Returning empty list of HGVS identifiers.");
                         return null;
@@ -252,6 +262,11 @@ public class HgvsProteinCalculator {
 
         int codonPosition = transcriptUtils.getCodonPosition(cdsVariantStartPosition);
         int positionAtCodon = transcriptUtils.getPositionAtCodon(cdsVariantStartPosition);
+
+        // No prediction to be made if the variant falls on the first codon and this codon is incomplete
+        if (positionAtCodon == 0) {
+            return null;
+        }
 
         // Check if this is an in an insertion, duplication or frameshift.
         // Alternate length for Insertions and Duplications must be multiple of 3, otherwise it is a frameshift.

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/HgvsProteinCalculator.java
@@ -339,7 +339,7 @@ public class HgvsProteinCalculator {
                 }
 
                 // Check if the the original amino acid is kept
-                if (StringUtils.isNotEmpty(refAa) && refAa.equalsIgnoreCase(insertLeftAa) || refAa.equalsIgnoreCase(insertRightAa)) {
+                if (StringUtils.isNotEmpty(refAa) && (refAa.equalsIgnoreCase(insertLeftAa) || refAa.equalsIgnoreCase(insertRightAa))) {
                     // Check if the new sequence is inserted left or right to the original reference codon.
                     // Remove the reference codon and update codonPosition for the insertion
                     if (refAa.equalsIgnoreCase(insertLeftAa)) {

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/TranscriptUtils.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/TranscriptUtils.java
@@ -130,7 +130,9 @@ public class TranscriptUtils {
             cdnaCodonStart = cdnaCodonStart - 1;
 
             int cdnaCodonEnd = Math.min(cdnaCodonStart + 3, transcript.getCdnaCodingEnd());
-            return transcript.getCdnaSequence().substring(cdnaCodonStart, cdnaCodonEnd);
+            if (cdnaCodonStart >= 0 && transcript.getCdnaSequence().length() > cdnaCodonEnd) {
+                return transcript.getCdnaSequence().substring(cdnaCodonStart, cdnaCodonEnd);
+            }
         }
         return "";
     }
@@ -299,6 +301,9 @@ public class TranscriptUtils {
             case DELETION:
             case INDEL:
                 if (StringUtils.isBlank(variant.getReference()) || variant.getReference().equals("-")) {
+                    if (cdnaVariantIndex < 0) {
+                        return null;
+                    }
                     // Insertion
                     alternateCdnaSequence.insert(cdnaVariantIndex, alternate);
                 } else {
@@ -357,6 +362,9 @@ public class TranscriptUtils {
                             variantCdsPosition--;
                         }
                         cdnaVariantIndex = cdsToCdna(variantCdsPosition) - 1;
+                        if (cdnaVariantIndex < 0 || alternateCdnaSequence.length() < cdnaVariantIndex + referenceAllele.length()) {
+                            return null;
+                        }
                         alternateCdnaSequence.replace(cdnaVariantIndex, cdnaVariantIndex + referenceAllele.length(), "");
                     } else {
                         System.out.println("No valid INDEL variant: " + variant.getId());

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/TranscriptUtils.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/TranscriptUtils.java
@@ -130,7 +130,7 @@ public class TranscriptUtils {
             cdnaCodonStart = cdnaCodonStart - 1;
 
             int cdnaCodonEnd = Math.min(cdnaCodonStart + 3, transcript.getCdnaCodingEnd());
-            if (cdnaCodonStart >= 0 && transcript.getCdnaSequence().length() > cdnaCodonEnd) {
+            if (cdnaCodonStart >= 0 && transcript.getCdnaSequence().length() >= cdnaCodonEnd) {
                 return transcript.getCdnaSequence().substring(cdnaCodonStart, cdnaCodonEnd);
             }
         }

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/TranscriptUtils.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/TranscriptUtils.java
@@ -130,7 +130,7 @@ public class TranscriptUtils {
             cdnaCodonStart = cdnaCodonStart - 1;
 
             int cdnaCodonEnd = Math.min(cdnaCodonStart + 3, transcript.getCdnaCodingEnd());
-            if (cdnaCodonStart >= 0 && transcript.getCdnaSequence().length() >= cdnaCodonEnd) {
+            if (cdnaCodonStart >= 0 && transcript.getCdnaSequence().length() > cdnaCodonEnd) {
                 return transcript.getCdnaSequence().substring(cdnaCodonStart, cdnaCodonEnd);
             }
         }

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/TranscriptUtils.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/hgvs/TranscriptUtils.java
@@ -129,8 +129,8 @@ public class TranscriptUtils {
             // Adjust for manipulating strings, set to be zero base
             cdnaCodonStart = cdnaCodonStart - 1;
 
-            int cdnaCodonEnd = Math.min(cdnaCodonStart + 3, transcript.getCdnaCodingEnd());
-            if (cdnaCodonStart >= 0 && transcript.getCdnaSequence().length() > cdnaCodonEnd) {
+            int cdnaCodonEnd = cdnaCodonStart + 3;
+            if (cdnaCodonStart >= 0 && transcript.getCdnaSequence().length() >= cdnaCodonEnd) {
                 return transcript.getCdnaSequence().substring(cdnaCodonStart, cdnaCodonEnd);
             }
         }


### PR DESCRIPTION
I tried merging via cherry-pick but v5 has diverged too much from v4 so I am doing this manually.


| |  Notes        | v4           | v5  | status |
| ------------ |-------------| -----| -----| ------------ |
| 1 |  some ClinVar accessions missing     | 31a15dbab83d030b74ec6094f3c99c0541686c90 | 6268cd9389cdc1c828c25b31e6674ec536a4af99| accepted |
| 2 |   hgvs-fixes: no HGVS is calculated for symbolic variants. Transcript HGVS no longer fails for long insertions. No HGVSp is calculated for insertions falling on an incomplete first codon| bfb307b7e6cfaa80b3d79a7bca79033ab90ee3d8     |    92d84c634eaa882a8fcefd215dc16a411a5a2bd0   |      accepted |
| 3 | HGVS - include context sequence for insertions to enable prediction of AAs |  0422f7f390011a9d3c9b737647b937014acc5145 | 6973ccc9028787eeb00560a6934fc83cbf024b72 | rejected |
| 4 | HGVS - Update to skip first codon if it's a frameshift, and the AA is M but the first codon is not ATG | 05ae55496a363e9209a0baac3b54cac57b8caca7 | 59ebe48a02ce473467e047a6ca3bfc63ddb98425 | FIXED |
| 5 | HGVS - one more null check | 5a3048308861f5bfd80a7d50e88cf28c7b07f1ea | 6987c002cb8fcef54c187ac5c952415dd59f7bb0 | rejected |
| 6 | HGVS - add some null checks when calculating HGVSp for edge case variants | 28099e382774d10fec8a14ff3c91e1b9a1cfcfef | 2841a3a63b8b384942653f795313e06c4185891d | REJECTED (see below) |
| 7 | fix clinvar normalisation issue, clinvar has the incorrect locations for normalised deletion variants | 87e85e10f4c1ae5ee4f62d0a7cca5d3dd8faac1e | 1f2f34f1e4f8026424ac16d6c393318b8b3a5023 | accepted |
| 8 | use complement for negative strand, allows MNVs to calculate consequence types correctly when phased | 2e5f0d077ae63aacaccad0d3b7241a23d3e2389d, e3ef4b2632f43d584455c950d2a2a12534c689d8 | a88fc98e478aec3e3c0b9891e6b685b866d43257 | accepted |
| 9 | remove threshold for indel annotation | 023112c165fedc796328bf579bb87e3a414c41df | 8a24f6ffa2b2bb6df979996311469f458f5b20b3 | accepted |
| 10 | An exception is thrown when the variant was the penultimate NT in the transcript sequence | | ac289d2fcd10c8a0af3163b0fca6ffc149ba915a | accepted (add comment with link to commit) |
| 11 | Annotating variants in RET,BRCA1 at the same time caused the wrong ClinVar annotations to be returned. Added chromosome to the check | | d53de94830b3305faf86ad2df6344083ee798246 | accepted |

### Null pointer exceptions



Variants that caused the NULL pointer exception. From ClinVar file: `ClinVarFullRelease_2021-01.xml.gz`. 

| fix | notes | count | variant |
| --- |---------| --------- |  --------- | 
| 1 | -- | 0 | -- | 
| 2 | -- | 0 | -- | 
| [3](https://github.com/opencb/cellbase/pull/555/files#diff-cb53ae8cda3d9bdcbd71145b870f05d8feb354da9a329382d38890ca52ba4dbfR304) |  positionAtCodon:2 refCodon: empty | 2| 2:219614086-219614085::TCC |
| [4](https://github.com/opencb/cellbase/pull/555/files#diff-cb53ae8cda3d9bdcbd71145b870f05d8feb354da9a329382d38890ca52ba4dbfR449) |  aminoacidPosition:156 transcript.getProteinSequence().length():155 |14|14:73640400-73640399::ATTTAT |
| [5](https://github.com/opencb/cellbase/pull/555/files#diff-cb53ae8cda3d9bdcbd71145b870f05d8feb354da9a329382d38890ca52ba4dbfR459) | aminoacidPosition:94 transcript.getProteinSequence().length():93  |9|11:108099994-108099993::AAAAGATGC | 
| [6](https://github.com/opencb/cellbase/pull/555/files#diff-cb53ae8cda3d9bdcbd71145b870f05d8feb354da9a329382d38890ca52ba4dbfR827) | leftAminoAcidPosition:1014 rightAminoAcidPosition 1014 transcript.getProteinSequence().length():1013 |12|19:42471091-42471090::AGT |  
| [7](https://github.com/opencb/cellbase/pull/555/files#diff-cb53ae8cda3d9bdcbd71145b870f05d8feb354da9a329382d38890ca52ba4dbfR910) |  alternateCdnaSeq is null |5|19:11217360-11218068:TAATGGTGAGCGCTGGCCATCTGGTTTTCCATCCCCCATTCTCTGTGCCTTGCTGCTTGCAAATGATTTGTGAAGCCAGAGGGCGCTTCCCTGGTCAGCTCTGCACCAGCTGTGCGTCTGTGGGCAAGTGACTTGACTTCTCAGAGCCTCACTTCCTTTTGTTTTGAGACGGAGTCTCGCTCTGACACCCAGGCTGGAGTGCTGTGGCACAATCACAGCTCACGGCAGCCTCTGCCTCTGATGTCCAGTGATTCTCCTGCCTCAGCCTCCCGAGTAGCTGAGATTAAAGGCGTATACCACCACGCCCGGCTAATTTTTTGTATTTTTATTAGAGACAGGGTTTCTCCATGTTGGCCAGGCTGGTCTTGAACTCCTGGTCTCAGGTGATCCACCCGCCTCGGCCTCCCAAAGTGCTAGGATTACAGGTGTGAGCCACTGCGCCAGGCCTAATTTTTTTGTATTTTTAGTAGAGATGCGGTTTTGCCATATTGCCCAGGCTGGTCTCGAACTCCTGGGCTCAAGCGATCTGCCTGCCTTGGCCTCCCAAAGTGCTGGGATTACAGGCACAAACCACCGTGCCCGACGCGTTTTCTTAATGAATCCATTTGCATGCGTTCTTATGTGAATAAACTATTATATGAATGAGTGCCAAGCAAACTGAGGCTCAGACACACCTGACCTTCCTCCTTCCTCTCTCTGGCTCTCACAG | 



