### PR TITLE
Add a Maven profile

### DIFF
--- a/.github/workflows/junit.yml
+++ b/.github/workflows/junit.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Clone and build java-common-libs
       run: cd ~ && git clone -b develop https://github.com/opencb/java-common-libs.git && cd ~/java-common-libs && mvn -T 2 clean install -DskipTests && cd $GITHUB_WORKSPACE
     - name: Clone and build biodata
-      run: cd ~ && git clone -b develop https://github.com/opencb/biodata.git && cd ~/biodata && mvn -T 2 clean install -DskipTests && cd $GITHUB_WORKSPACE
+      # remove copying over the .mvn directory once the HTTP repo is removed
+      run: cd ~ && git clone -b develop https://github.com/opencb/biodata.git && cd ~/biodata && cp -ar $GITHUB_WORKSPACE/.mvn . && mvn -T 2 clean install -DskipTests && cd $GITHUB_WORKSPACE
     - name: Build with Maven
       run: mvn -T 2 clean install

--- a/.mvn/README
+++ b/.mvn/README
@@ -1,0 +1,1 @@
+ Hack to get around Maven blocking HTTP repos. Once CellBase does not have any HTTP dependencies, delete this directory.

--- a/.mvn/local-settings.xml
+++ b/.mvn/local-settings.xml
@@ -1,0 +1,20 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>release-opencb-ext-libs</id>
+            <mirrorOf>opencb-ext-libs</mirrorOf>
+            <name></name>
+            <url>http://bioinfo.hpc.cam.ac.uk/downloads/ext-libs/</url>
+            <blocked>false</blocked>
+        </mirror>
+        <mirror>
+            <id>release-maven-restlet</id>
+            <mirrorOf>maven-restlet</mirrorOf>
+            <name></name>
+            <url>http://maven.restlet.org</url>
+            <blocked>false</blocked>
+        </mirror>
+    </mirrors>
+</settings>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+ --settings .mvn/local-settings.xml


### PR DESCRIPTION
Maven no longer allows repos from HTTP sources

https://maven.apache.org/docs/3.8.1/release-notes.html

BigWig is used by biodata, and is hosted locally at the University but with HTTP. (OpenCGA has another dependency that is HTTP).

This pull request:

1. creates a maven profile that whitelists the bigwig library
2. copies in the `.mvn` directory to the biodata repo

This change is also needed in OpenCGA.

This is a temporary fix, to be removed when the HTTP repos are moved to HTTPS.