### PR TITLE
PyCellBase: use version from pom file

### DIFF
--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -151,10 +151,19 @@
                                     <arg value="${build.dir}"/>
                                 </exec>
 
-                                <echo>Copying to ${build.dir}/clients</echo>
+                                <echo>Copying Python and R to ${build.dir}/clients</echo>
                                 <exec executable="cp">
                                     <arg value="-r"/>
                                     <arg value="${project.basedir}/../cellbase-client/src/main/python"/>
+                                    <arg value="${build.dir}/clients"/>
+                                </exec>
+                                <exec executable="sed">
+                                    <arg value="-i"/>
+                                    <arg value="s/PYCELLBASE_VERSION/${cellbase.version}/"/>
+                                    <arg value="${build.dir}/clients/python/setup.py"/>
+                                </exec>
+                                <exec executable="cp">
+                                    <arg value="-r"/>
                                     <arg value="${project.basedir}/../cellbase-client/src/main/R"/>
                                     <arg value="${build.dir}/clients"/>
                                 </exec>

--- a/cellbase-client/src/main/python/setup.py
+++ b/cellbase-client/src/main/python/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup_kwargs = {
     'name': 'pycellbase',
-    'version': '4.7.1',
+    'version': 'PYCELLBASE_VERSION',
     'description': 'Python client for CellBase',
     'long_description': long_description,
     'long_description_content_type': 'text/x-rst',

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <cellbase.version>5.0.0-SNAPSHOT</cellbase.version>
         <java-common-libs.version>4.1.0-SNAPSHOT</java-common-libs.version>
+        <pycellbase.version>${cellbase.version}</pycellbase.version>
         <biodata.version>2.1.0-SNAPSHOT</biodata.version>
         <bionetdb.version>0.1.0</bionetdb.version>
         <jackson.version>2.10.1</jackson.version>


### PR DESCRIPTION
Use the version from the pom.xml file instead of hardcoding it in setup.py.

However, there is still a version in `__init__.py`. But that looks different in opencga: https://github.com/opencb/opencga/blob/develop/opencga-client/src/main/python/pyopencga/__init__.py