### PR TITLE
Add logging to HGVSc generation, lower log level

### DIFF
--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.4-SNAPSHOT</version>
+        <version>4.10.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.3</version>
+        <version>4.10.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.4-SNAPSHOT</version>
+        <version>4.10.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.3</version>
+        <version>4.10.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.4-SNAPSHOT</version>
+        <version>4.10.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.3</version>
+        <version>4.10.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
@@ -451,7 +451,7 @@ public class VariantAnnotationCalculator {
                             .setDisplayConsequenceType(getMostSevereConsequenceType(normalizedVariantList.get(i)
                                     .getAnnotation().getConsequenceTypes()));
                 } catch (UnsupportedURLVariantFormat e) {
-                    logger.error("Consequence type was not calculated for variant {}. Unrecognised variant format."
+                    logger.warn("Consequence type was not calculated for variant {}. Unrecognised variant format."
                             + " Leaving an empty consequence type list.", normalizedVariantList.get(i).toString());
                     variantAnnotation.setConsequenceTypes(Collections.emptyList());
                 } catch (Exception e) {

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/hgvs/HgvsProteinCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/hgvs/HgvsProteinCalculator.java
@@ -92,7 +92,7 @@ public class HgvsProteinCalculator {
                 }
             default:
                 // TODO throw an error?
-                logger.error("Don't know how to handle this variant of type {}", variant.getType());
+                logger.warn("Can't generate HGVS for variant type {}", variant.getType());
                 return null;
         }
     }
@@ -972,7 +972,9 @@ public class HgvsProteinCalculator {
                     if (firstDiffIndex == -1) {
                         String longAA = VariantAnnotationUtils.TO_LONG_AA.get(referenceCodedAa);
                         if (StringUtils.isEmpty(longAA)) {
-                            logger.error("Invalid AA found: " + referenceCodedAa + " for variant " + variant.getId());
+                            logger.info("Invalid AA found: " + referenceCodedAa + " for variant "
+                                    + variant.getChromosome() + ":" + variant.getStart() + "-" + variant.getEnd()
+                                    + ":" + variant.getReference() + ":" + variant.getAlternate());
                             return null;
                         }
                         firstReferencedAa = StringUtils.capitalize(longAA.toLowerCase());

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/hgvs/HgvsTranscriptCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/hgvs/HgvsTranscriptCalculator.java
@@ -422,7 +422,18 @@ public class HgvsTranscriptCalculator {
         int end = variant.getStart() + neighbouringSequenceSize + variant.getAlternate().length(); // TODO: might need to adjust +-1 nt
         Query query = new Query(GenomeDBAdaptor.QueryParams.REGION.key(), variant.getChromosome()
                 + ":" + start + "-" + end);
-        String genomicSequence = genomeDBAdaptor.getGenomicSequence(query, new QueryOptions()).getResult().get(0).getSequence();
+
+        QueryResult<GenomeSequenceFeature> queryResult = genomeDBAdaptor.getGenomicSequence(query, new QueryOptions());
+        if (queryResult.getResult() == null || queryResult.getResult().size() == 0) {
+            String msg = new StringBuilder().append("Error calculating HGVSc for ").append(variant.toJson())
+                    .append(". No sequence found for ")
+                    .append(variant.getChromosome()).append(":").append(start).append("-").append(end)
+                    .append(". Query attempted was: ").append(query.toJson())
+                    .append(". Transcript: " + transcript.getId())
+                    .toString();
+            throw new RuntimeException(msg);
+        }
+        String genomicSequence = queryResult.getResult().get(0).getSequence();
 
         // Create normalizedVariant and justify sequence to the right/left as appropriate
         normalizedVariant.setChromosome(variant.getChromosome());

--- a/cellbase-core/src/main/resources/log4j2.xml
+++ b/cellbase-core/src/main/resources/log4j2.xml
@@ -1,36 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
-    <Properties>
-        <Property name="name">cellbase</Property>
-        <Property name="baseDir">${sys:app.home:-${log4j:configParentLocation}/../}</Property>
-        <Property name="logDir">${sys:cellbase.log.dir:-${baseDir}/logs}</Property>
-        <Property name="logFile">${name}.${hostName}.log</Property>
-        <Property name="logFileArchive">${name}.${hostName}.%i.log.gz</Property>
-    </Properties>
+<Configuration status="WARN">
     <Appenders>
-        <RollingFile name="RollingFileJson"
-                     append="true"
-                     immediateFlush="true"
-                     fileName="${logFile}"
-                     filePattern="${logFileArchive}"
-                     createOnDemand="true"
-                     ignoreExceptions="false">
-            <Policies>
-                <SizeBasedTriggeringPolicy size="100 MB" />
-                <!--                <OnStartupTriggeringPolicy />-->
-                <!--                <TimeBasedTriggeringPolicy />-->
-            </Policies>
-            <DefaultRolloverStrategy max="20"/>
+        <Console name="Console" target="SYSTEM_ERR">
+            <ThresholdFilter level="${sys:cellbase.log.level:-info}" onMatch="ACCEPT" onMismatch="DENY"/>
+            <JsonLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeTimeMillis="true">
+            </JsonLayout>
+        </Console>
 
-            <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true"/>
-            <ThresholdFilter level="DEBUG" onMatch="ACCEPT" onMismatch="DENY"/>
-        </RollingFile>
     </Appenders>
     <Loggers>
-        <Root level="DEBUG">
-            <AppenderRef ref="RollingFileJson" />
-        </Root>
-        <Logger name="org.mongodb.driver.cluster" level="WARN"/>
-        <Logger name="org.mongodb.driver.connection" level="WARN"/>
+        <Root  level="INFO">
+            <AppenderRef ref="Console" />
+        </Root >
+
+        <Logger  name="org.mongodb.driver.cluster" level="WARN"/>
+        <Logger  name="org.mongodb.driver.connection" level="WARN"/>
     </Loggers>
 </Configuration>

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.4-SNAPSHOT</version>
+        <version>4.10.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.3</version>
+        <version>4.10.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.4-SNAPSHOT</version>
+        <version>4.10.4</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.10.3</version>
+        <version>4.10.4-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-server/src/main/resources/log4j2.xml
+++ b/cellbase-server/src/main/resources/log4j2.xml
@@ -1,41 +1,18 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Configuration>
-    <Properties>
-        <Property name="name">cellbase</Property>
-        <Property name="logFile">${cellbase.log.file}</Property>
-        <Property name="logFileArchive">${cellbase.log.file}.%i.log.gz</Property>
-    </Properties>
+<Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_ERR">
-            <JSONLayout compact="true" eventEol="true" propertiesAsList="true" objectMessageAsJsonObject="true"
-                        includeStacktrace="true" includeTimeMillis="true"/>
-            <ThresholdFilter level="INFO" onMatch="ACCEPT" onMismatch="DENY"/>
+            <ThresholdFilter level="${sys:cellbase.log.level:-info}" onMatch="ACCEPT" onMismatch="DENY"/>
+            <JsonLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" includeTimeMillis="true">
+            </JsonLayout>
         </Console>
-        <RollingFile name="RollingFileJson"
-                     append="true"
-                     immediateFlush="true"
-                     fileName="${logFile}"
-                     filePattern="${logFileArchive}"
-                     createOnDemand="true"
-                     ignoreExceptions="false">
-            <Policies>
-                <SizeBasedTriggeringPolicy size="100 MB" />
-                <!--                <OnStartupTriggeringPolicy />-->
-                <!--                <TimeBasedTriggeringPolicy />-->
-            </Policies>
-            <DefaultRolloverStrategy max="20"/>
 
-            <JSONLayout compact="true" eventEol="true" propertiesAsList="true" objectMessageAsJsonObject="true"
-                        includeStacktrace="true" includeTimeMillis="true"/>
-            <ThresholdFilter level="DEBUG" onMatch="ACCEPT" onMismatch="DENY"/>
-        </RollingFile>
     </Appenders>
     <Loggers>
-        <Root level="INFO">
-            <AppenderRef ref="RollingFileJson" />
+        <Root  level="INFO">
             <AppenderRef ref="Console" />
-        </Root>
-        <Logger name="org.mongodb.driver.cluster" level="WARN"/>
-        <Logger name="org.mongodb.driver.connection" level="WARN"/>
+        </Root >
+
+        <Logger  name="org.mongodb.driver.cluster" level="WARN"/>
+        <Logger  name="org.mongodb.driver.connection" level="WARN"/>
     </Loggers>
 </Configuration>

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.10.4-SNAPSHOT</version>
+    <version>4.10.4</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.10.3</version>
+    <version>4.10.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.10.4-SNAPSHOT</version>
+    <version>4.10.4</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.10.4-SNAPSHOT</cellbase.version>
+        <cellbase.version>4.10.4</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.6</biodata.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.10.3</version>
+    <version>4.10.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.10.3</cellbase.version>
+        <cellbase.version>4.10.4-SNAPSHOT</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.6</biodata.version>


### PR DESCRIPTION
An error occurs when calculating HGVSc for deletions:

```
{u'errorMsg': u'DEPRECATED: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0', u'warningMsg': u'Future errors will ONLY be shown in the QueryResponse body', u'numTotalResults': -1, u'numResults': -1, u'resultType': u'', u'result': [], u'id': u'', u'dbTime': -1}
```
Error only occurs under heavy load. When the job is resubmitted, the query works as expected. However, given the number of cases processed using CellBase, this solution isn't scalable. (500 cases with 40% failing)

https://github.com/opencb/cellbase/blob/release-4.9.x/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/hgvs/HgvsTranscriptCalculator.java#L423

I have checked:

* memory, CPU
* disk space
* open file descriptors
* database connections (2000 - not exhausted)
* log messages
* database indexes 
* mongo nodes synced (I queried each node individually)

There have been no recent changes to the environment or config. This is an ongoing problem, first reported last year. It's become a priority for me as it's now a blocking issue due to the increased demand on CellBase..