### PR TITLE
add logging to HGVSc insertion/deletion calculations

### DIFF
--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.10</version>
+        <version>4.9.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.10</version>
+        <version>4.9.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.10</version>
+        <version>4.9.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
@@ -434,7 +434,7 @@ public class VariantAnnotationCalculator {
                     //     variants are not normalized the user should always select normalize=true.
                     variantAnnotation.setHgvs(hgvsCalculator.run(normalizedVariantList.get(i), variantGeneList, false));
                 } catch (VariantNormalizerException e) {
-                    logger.error("Unable to normalize variant {}. Leaving empty HGVS.",
+                    logger.warn("Unable to normalize variant {}. Leaving empty HGVS.",
                             normalizedVariantList.get(i).toString());
                 }
             }
@@ -451,11 +451,11 @@ public class VariantAnnotationCalculator {
                             .setDisplayConsequenceType(getMostSevereConsequenceType(normalizedVariantList.get(i)
                                     .getAnnotation().getConsequenceTypes()));
                 } catch (UnsupportedURLVariantFormat e) {
-                    logger.error("Consequence type was not calculated for variant {}. Unrecognised variant format."
+                    logger.warn("Consequence type was not calculated for variant {}. Unrecognised variant format."
                             + " Leaving an empty consequence type list.", normalizedVariantList.get(i).toString());
                     variantAnnotation.setConsequenceTypes(Collections.emptyList());
                 } catch (Exception e) {
-                    logger.error("Unhandled error when calculating consequence type for variant {}. Leaving an empty"
+                    logger.warn("Unhandled error when calculating consequence type for variant {}. Leaving an empty"
                             + " consequence type list.", normalizedVariantList.get(i).toString());
                     e.printStackTrace();
                     variantAnnotation.setConsequenceTypes(Collections.emptyList());

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationUtils.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationUtils.java
@@ -601,6 +601,11 @@ public class VariantAnnotationUtils {
         return new SequenceOntologyTerm(ConsequenceTypeMappings.getSoAccessionString(name), name);
     }
 
+    public static String buildVariantId(Variant variant) {
+        return buildVariantId(variant.getChromosome(), variant.getStart(), variant.getReference(),
+                variant.getAlternate());
+    }
+
     public static String buildVariantId(String chromosome, int start, String reference, String alternate) {
         StringBuilder stringBuilder = new StringBuilder();
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/hgvs/HgvsProteinCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/hgvs/HgvsProteinCalculator.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
+import static org.opencb.cellbase.core.variant.annotation.VariantAnnotationUtils.buildVariantId;
+
 /**
  * Calculates HGVS protein string based on variant and transcript.
  */
@@ -91,8 +93,7 @@ public class HgvsProteinCalculator {
                     return null;
                 }
             default:
-                // TODO throw an error?
-                logger.error("Don't know how to handle this variant of type {}", variant.getType());
+                logger.warn("Don't know how to handle this variant of type {}", variant.getType());
                 return null;
         }
     }
@@ -279,16 +280,16 @@ public class HgvsProteinCalculator {
 
                 // Build the new inserted sequence = split codon + alternate allele
                 if (refCodon.length() < positionAtCodon) {
-                    logger.error("INVALID VARIANT 3: positionAtCodon:" + positionAtCodon + " refCodon:" + refCodon + " variantId:"
-                            + getVariantId(variant));
+                    logger.warn("INVALID VARIANT 3: positionAtCodon:" + positionAtCodon + " refCodon:" + refCodon + " variantId:"
+                            + buildVariantId(variant));
                     return null;
                 }
                 String insSequence = refCodon.substring(0, positionAtCodon - 1) + alternate + refCodon.substring(positionAtCodon - 1);
 
                 // need inserted sequence to be divisible by 3 to predict AAs later
                 if (insSequence.length() % 3 > 0) {
-                    logger.error("INVALID VARIANT 1: insSequence:" + insSequence + " refCodon:" + refCodon + " variantId:"
-                            + getVariantId(variant));
+                    logger.warn("INVALID VARIANT 1: insSequence:" + insSequence + " refCodon:" + refCodon + " variantId:"
+                            + buildVariantId(variant));
                     // append NTs until sequence has enough codons
                     insSequence = insSequence + refCodon.substring(0, (3 - insSequence.length() % 3));
                 }
@@ -321,7 +322,7 @@ public class HgvsProteinCalculator {
                 }
 
                 if (StringUtils.isEmpty(refAa)) {
-                    logger.error("INVALID VARAINT 2: empty refAa :: " + getVariantId(variant));
+                    logger.warn("INVALID VARAINT 2: empty refAa :: " + buildVariantId(variant));
                 }
 
                 // Check if the the original amino acid is kept
@@ -432,8 +433,8 @@ public class HgvsProteinCalculator {
             // keep moving to the right (3' Rule) while the first amino acid deleted equals the first one after deletion,
             // Example: check 11:6390701:-:CTGGCGCTGGCG
             if (transcript.getProteinSequence().length() < aminoacidPosition) {
-                logger.error("INVALID VARIANT 4: aminoacidPosition:" + aminoacidPosition + " transcript.getProteinSequence().length():"
-                        + transcript.getProteinSequence().length() + " variantId:" + getVariantId(variant));
+                logger.warn("INVALID VARIANT 4: aminoacidPosition:" + aminoacidPosition + " transcript.getProteinSequence().length():"
+                        + transcript.getProteinSequence().length() + " variantId:" + buildVariantId(variant));
                 return null;
             }
             String aaAfterInsertion = transcript.getProteinSequence().substring(aminoacidPosition - 1, aminoacidPosition);
@@ -444,8 +445,8 @@ public class HgvsProteinCalculator {
                 aminoacids.add(VariantAnnotationUtils.TO_LONG_AA.get(aaAfterInsertion));
                 codedAminoacids.add(aaAfterInsertion);
                 if (aminoacidPosition <= 0 || transcript.getProteinSequence().length() < aminoacidPosition) {
-                    logger.error("INVALID VARIANT 5: aminoacidPosition:" + aminoacidPosition + " transcript.getProteinSequence().length():"
-                            + transcript.getProteinSequence().length() + " variantId:" + getVariantId(variant));
+                    logger.warn("INVALID VARIANT 5: aminoacidPosition:" + aminoacidPosition + " transcript.getProteinSequence().length():"
+                            + transcript.getProteinSequence().length() + " variantId:" + buildVariantId(variant));
                     return null;
                 }
                 aaAfterInsertion = transcript.getProteinSequence().substring(aminoacidPosition - 1, aminoacidPosition);
@@ -675,7 +676,7 @@ public class HgvsProteinCalculator {
                     newAlternateCodon = firstAffectedCodon.substring(0, positionAtCodon - 1)
                         + lastAffectedCodon.substring(positionAtCodon - 1); // GA + C = GAC
                 } else {
-                    logger.error("Couldn't calculate HGVSp for " + variant.getId());
+                    logger.warn("Couldn't calculate HGVSp for " + variant.getId());
                     return null;
                 }
 
@@ -814,9 +815,9 @@ public class HgvsProteinCalculator {
         if (leftAminoAcidPosition < 1 || rightAminoAcidPosition < 1 || transcript.getProteinSequence() == null
                 || transcript.getProteinSequence().length() < leftAminoAcidPosition
                 || transcript.getProteinSequence().length() < rightAminoAcidPosition) {
-            logger.error("INVALID VARIANT 6: leftAminoAcidPosition:" + leftAminoAcidPosition + " rightAminoAcidPosition "
+            logger.warn("INVALID VARIANT 6: leftAminoAcidPosition:" + leftAminoAcidPosition + " rightAminoAcidPosition "
                     + rightAminoAcidPosition + " transcript" + ".getProteinSequence().length():"
-                    + transcript.getProteinSequence().length() + " variantId:" + getVariantId(variant));
+                    + transcript.getProteinSequence().length() + " variantId:" + buildVariantId(variant));
             return null;
         }
         String leftCodedAa = transcript.getProteinSequence().substring(leftAminoAcidPosition - 1, leftAminoAcidPosition);
@@ -900,7 +901,7 @@ public class HgvsProteinCalculator {
         String alternateCdnaSeq = transcriptUtils.getAlternateCdnaSequence(variant);
 
         if (alternateCdnaSeq == null) {
-            logger.error("INVALID VARIANT 7: variantId:" + getVariantId(variant));
+            logger.warn("INVALID VARIANT 7: variantId:" + buildVariantId(variant));
             return null;
         }
         int codonIndex = transcript.getCdnaCodingStart() - 1;
@@ -931,7 +932,7 @@ public class HgvsProteinCalculator {
             currentAaIndex++;
             codonIndex += 3;
 
-            logger.info("NON-ATG START: " + getVariantId(variant));
+            logger.debug("NON-ATG START: " + buildVariantId(variant));
         }
 
 
@@ -972,7 +973,8 @@ public class HgvsProteinCalculator {
                     if (firstDiffIndex == -1) {
                         String longAA = VariantAnnotationUtils.TO_LONG_AA.get(referenceCodedAa);
                         if (StringUtils.isEmpty(longAA)) {
-                            logger.error("Invalid AA found: " + referenceCodedAa + " for variant " + variant.getId());
+                            logger.warn("Invalid AA found: " + referenceCodedAa + " for variant "
+                                    + buildVariantId(variant));
                             return null;
                         }
                         firstReferencedAa = StringUtils.capitalize(longAA.toLowerCase());
@@ -1077,9 +1079,6 @@ public class HgvsProteinCalculator {
         return proteinIds;
     }
 
-    private String getVariantId(Variant variant) {
-        return  variant.getChromosome() + ":" + variant.getStart() + "-" + variant.getEnd() + ":" + variant.getReference() + ":"
-                + variant.getAlternate();
-    }
+
 
 }

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.10</version>
+        <version>4.9.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.9.10</version>
+        <version>4.9.9-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.9.10</version>
+    <version>4.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <cellbase.version>4.9.9-SNAPSHOT</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
-        <biodata.version>1.5.6</biodata.version>
+        <biodata.version>1.5.5</biodata.version>
         <bionetdb.version>0.1.0</bionetdb.version>
         <jackson.version>2.9.8</jackson.version>
         <protobuf.version>3.1.0</protobuf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.9.10</version>
+    <version>4.9.9-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.9.10</cellbase.version>
+        <cellbase.version>4.9.9-SNAPSHOT</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.6</biodata.version>


### PR DESCRIPTION
There should be NO functional changes between this branch and v4.9.8. 

Changes include:

* add a log message to calculations for HGVSc insertions / deletions
* NO change to exception thrown. I didn't add a catch because I didn't want to change behaviour.
* demote some ERRORs to WARNs to declutter log files. Only immediately actionable errors should be labeled ERROR
* reverted previous security patches. Those go in v4.10.x instead. This branch should have NO functional changes from v4.9.8

Specifically, is there more information I can put in the log message that might help give us more information?