### PR TITLE
Remove docker queries from download

### DIFF
--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/download/GeneDownloadManager.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/download/GeneDownloadManager.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang.StringUtils;
 import org.opencb.cellbase.core.config.CellBaseConfiguration;
 import org.opencb.cellbase.core.exception.CellBaseException;
 import org.opencb.cellbase.lib.EtlCommons;
-import org.opencb.commons.utils.DockerUtils;
 import org.opencb.commons.utils.FileUtils;
 
 import java.io.BufferedReader;
@@ -46,7 +45,6 @@ public class GeneDownloadManager extends AbstractDownloadManager {
     private static final String GO_ANNOTATION_NAME = "EBI Gene Ontology Annotation";
     private static final String DGIDB_NAME = "DGIdb";
     private static final String GNOMAD_NAME = "gnomAD";
-    private static String dockerImage;
 
     private static final Map<String, String> GENE_UNIPROT_XREF_FILES;
 
@@ -63,8 +61,6 @@ public class GeneDownloadManager extends AbstractDownloadManager {
     public GeneDownloadManager(String species, String assembly, Path targetDirectory, CellBaseConfiguration configuration)
             throws IOException, CellBaseException {
         super(species, assembly, targetDirectory, configuration);
-
-        dockerImage = "opencb/cellbase-builder:" + configuration.getApiVersion();
     }
 
     @Override
@@ -88,7 +84,6 @@ public class GeneDownloadManager extends AbstractDownloadManager {
         downloadFiles.addAll(downloadGeneDiseaseAnnotation(geneFolder));
         downloadFiles.add(downloadGnomadConstraints(geneFolder));
         downloadFiles.add(downloadGO(geneFolder));
-//        runGeneExtraInfo(geneFolder);
 
         return downloadFiles;
     }
@@ -313,23 +308,5 @@ public class GeneDownloadManager extends AbstractDownloadManager {
                 Collections.singletonList(host), geneFolder.resolve("disgenetVersion.json"));
 
         return downloadFiles;
-    }
-
-    private void runGeneExtraInfo(Path geneFolder) throws IOException, InterruptedException {
-        // TODO skip if we already have these data
-        logger.info("Downloading gene extra info ...");
-
-        if ("true".equals(System.getenv("CELLBASE_BUILD_DOCKER"))) {
-            final String outputLog = downloadLogFolder + "/gene_extra_info.log";
-            EtlCommons.runCommandLineProcess(null, "/opt/cellbase/gene_extra_info.pl",
-                    Arrays.asList("--outdir", geneFolder.toAbsolutePath().toString()),
-                    outputLog);
-        } else {
-            AbstractMap.SimpleEntry<String, String> outputBinding = new AbstractMap.SimpleEntry(geneFolder.toAbsolutePath().toString(),
-                    "/ensembl-data");
-            String ensemblScriptParams = "/opt/cellbase/gene_extra_info.pl --outdir /ensembl-data";
-
-            DockerUtils.run(dockerImage, null, outputBinding, ensemblScriptParams, null);
-        }
     }
 }

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/download/GenomeDownloadManager.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/download/GenomeDownloadManager.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang.StringUtils;
 import org.opencb.cellbase.core.config.CellBaseConfiguration;
 import org.opencb.cellbase.core.exception.CellBaseException;
 import org.opencb.cellbase.lib.EtlCommons;
-import org.opencb.commons.utils.DockerUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -51,7 +50,6 @@ public class GenomeDownloadManager extends AbstractDownloadManager {
 //        downloadFiles.addAll(downloadRepeats());
 
         // cytobands
-        runGenomeInfo();
         return downloadFiles;
     }
 
@@ -211,27 +209,5 @@ public class GenomeDownloadManager extends AbstractDownloadManager {
             return downloadFiles;
         }
         return null;
-    }
-
-    public void runGenomeInfo() throws IOException, InterruptedException {
-        logger.info("Downloading genome info ...");
-
-        // TODO don't run this if file already exists
-
-        String outputFolder = downloadFolder.getParent().toAbsolutePath().toString() + "/generated_json/";
-
-        if ("true".equals(System.getenv("CELLBASE_BUILD_DOCKER"))) {
-            String outputLog = downloadLogFolder + "/genome_info.log";
-            EtlCommons.runCommandLineProcess(null, "/opt/cellbase/genome_info.pl",
-                    Arrays.asList("--outdir", outputFolder),
-                    outputLog);
-        } else {
-            String dockerImage = "opencb/cellbase-builder:" + configuration.getApiVersion();
-
-            AbstractMap.SimpleEntry<String, String> outputBinding = new AbstractMap.SimpleEntry(outputFolder, "/ensembl-data");
-            String ensemblScriptParams = "/opt/cellbase/genome_info.pl";
-
-            DockerUtils.run(dockerImage, null, outputBinding, ensemblScriptParams, null);
-        }
     }
 }


### PR DESCRIPTION
We are automating the CellBase download. The ensembl scripts often fail so would like to remove them temporarily.

| Script  | Downloader | Product |
| ------------- | ------------- | ------------- | 
| gene_extra_info.pl  | GeneDownloader (was commented out)  | xrefs.txt and descriptions.txt |
| genome_info.pl | GenomeDownloader (see service desk ticket for error)  | cytobands |
| protein_function_prediction_matrices.pl | N/A - only a manual download?  | sift/polyphen2 |

And then we'd like to put a ticket in the Zetta backlog for how to download these data in a less manual way.

- Are these data still needed/ useful?
- Are these data available via flat files or the Ensembl REST API? It's been a while so maybe?
- If not, and the Ensembl Perl API is the only source of these data, can we improve these scripts so they are more robust? 
