### PR TITLE
Remove ensembl compara and funcgen 

### DIFF
--- a/cellbase-app/app/cloud/docker/cellbase-builder/Dockerfile
+++ b/cellbase-app/app/cloud/docker/cellbase-builder/Dockerfile
@@ -24,8 +24,6 @@ RUN cd /opt/ensembl && \
     git clone https://github.com/Ensembl/ensembl-git-tools.git && \
     git clone https://github.com/Ensembl/ensembl.git && \
     git clone https://github.com/Ensembl/ensembl-variation.git && \
-    git clone https://github.com/Ensembl/ensembl-funcgen.git && \
-    git clone https://github.com/Ensembl/ensembl-compara.git && \
     git clone https://github.com/Ensembl/ensembl-io.git
 
 ENV PERL5LIB=$PERL5LIB:/opt/ensembl/bioperl-live:/opt/ensembl/ensembl/modules:/opt/ensembl/ensembl-variation/modules:/opt/ensembl/ensembl-funcgen/modules:/opt/ensembl/ensembl-compara/modules:/opt/ensembl/lib/perl/5.18.2:/opt/cellbase


### PR DESCRIPTION
The gene and genome scripts use `core`, and the protein function prediction script uses `variation`. We never use compara or funcgen.

If you remove compara and funcgen repos, it cuts the size by half and the scripts still work. 

before
```
bash-5.1# du -ms /opt/ensembl/*
61      /opt/ensembl/bioperl-live
93      /opt/ensembl/ensembl
366     /opt/ensembl/ensembl-compara << never used. Remove!
41      /opt/ensembl/ensembl-funcgen << never used. Remove!
1       /opt/ensembl/ensembl-git-tools
228     /opt/ensembl/ensembl-variation
bash-5.1# du -hs /opt/ensembl/
786.9M  /opt/ensembl/
```
After
```
bash-5.1# du -ms /opt/ensembl/*
61      /opt/ensembl/bioperl-live
37      /opt/ensembl/ensembl
1       /opt/ensembl/ensembl-git-tools
13      /opt/ensembl/ensembl-io
116     /opt/ensembl/ensembl-variation
bash-5.1# du -ms /opt/ensembl
227     /opt/ensembl
```
