### PR TITLE
pad overlap queries too

### DIFF
--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.0</version>
+        <version>4.12.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.0</version>
+        <version>4.12.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.0</version>
+        <version>4.12.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
@@ -1117,6 +1117,9 @@ public class VariantAnnotationCalculator {
             return getRegulatoryRegionOverlaps(variant.getChromosome(), variant.getStart());
         } else if (VariantType.INDEL.equals(variant.getType()) && StringUtils.isBlank(variant.getReference())) {
             return getRegulatoryRegionOverlaps(variant.getChromosome(), variant.getStart() - 1, variant.getEnd());
+        } else if (VariantType.CNV.equals(variant.getType())) {
+            return getRegulatoryRegionOverlaps(variant.getChromosome(), variant.getStart() - cnvExtraPadding,
+                    variant.getEnd() + cnvExtraPadding);
         // Short deletions and symbolic variants except breakends
         } else if (!VariantType.BREAKEND.equals(variant.getType())) {
             return getRegulatoryRegionOverlaps(variant.getChromosome(), variant.getStart(), variant.getEnd());

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.0</version>
+        <version>4.12.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.0</version>
+        <version>4.12.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.12.0</version>
+    <version>4.12.1</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.12.0-SNAPSHOT</cellbase.version>
+        <cellbase.version>4.12.1</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.6</biodata.version>


### PR DESCRIPTION
the last fix didn't work as it was missing these SO terms:
* regulatory_region_variant
* TF_binding_site_variant
These are assigned in the getRegulatoryRegionOverlaps() which searchs on the variant start and end NOT the padded start and end. 