### PR TITLE
fix cnvpadding param. TEST FAILING

### DIFF
--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/ConsequenceTypeCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/ConsequenceTypeCalculator.java
@@ -32,6 +32,7 @@ import org.opencb.commons.datastore.core.Query;
 import org.opencb.commons.datastore.core.QueryOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.opencb.biodata.models.variant.avro.VariantType;
 
 import java.util.*;
 
@@ -73,7 +74,9 @@ public abstract class ConsequenceTypeCalculator {
     }
 
     protected int getStart(int extraPadding) {
-        if (imprecise && variant.getSv() != null) {
+        if (imprecise && VariantType.CNV.equals(variant.getType())) {
+            return variant.getStart() - extraPadding;
+        } else if (imprecise && variant.getSv() != null) {
             return variant.getSv().getCiStartLeft() != null ? variant.getSv().getCiStartLeft() - extraPadding
                     : variant.getStart();
         } else {
@@ -83,7 +86,9 @@ public abstract class ConsequenceTypeCalculator {
     }
 
     protected int getEnd(int extraPadding) {
-        if (imprecise && variant.getSv() != null) {
+        if (imprecise && VariantType.CNV.equals(variant.getType())) {
+            return variant.getEnd() + extraPadding;
+        } else if (imprecise && variant.getSv() != null) {
             return variant.getSv().getCiEndRight() != null ? variant.getSv().getCiEndRight() + extraPadding
                     : variant.getEnd();
         } else {

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/ConsequenceTypeGenericRegionCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/ConsequenceTypeGenericRegionCalculator.java
@@ -20,6 +20,7 @@ import org.opencb.biodata.models.core.Exon;
 import org.opencb.biodata.models.core.Gene;
 import org.opencb.biodata.models.core.Transcript;
 import org.opencb.biodata.models.variant.Variant;
+import org.opencb.biodata.models.variant.avro.VariantType;
 import org.opencb.biodata.models.variant.avro.ConsequenceType;
 import org.opencb.biodata.models.variant.avro.ExonOverlap;
 import org.opencb.cellbase.core.ParamConstants;
@@ -43,8 +44,9 @@ public class ConsequenceTypeGenericRegionCalculator extends ConsequenceTypeCalcu
         parseQueryParam(queryOptions);
         List<ConsequenceType> consequenceTypeList = new ArrayList<>();
         variant = inputVariant;
-        variantEnd = getEnd(svExtraPadding);
-        variantStart = getStart(svExtraPadding);
+        int extraPadding = VariantType.CNV.equals(variant.getType()) ? cnvExtraPadding : svExtraPadding;
+        variantEnd = getEnd(extraPadding);
+        variantStart = getStart(extraPadding);
 //        isBigDeletion = ((variantEnd - variantStart) > BIG_VARIANT_SIZE_THRESHOLD);
         boolean isIntergenic = true;
         for (Gene currentGene : geneList) {

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
@@ -587,8 +587,8 @@ public class VariantAnnotationCalculator {
 
             if (annotatorSet.contains("consequenceType")) {
                 try {
-                    List<ConsequenceType> consequenceTypeList = getConsequenceTypeList(variant, affectedGenes, true, QueryOptions.empty(),
-                            dataRelease);
+                    List<ConsequenceType> consequenceTypeList = getConsequenceTypeList(variant, affectedGenes, true,
+                            new QueryOptions().append("imprecise", imprecise).append("cnvExtraPadding", cnvExtraPadding), dataRelease);
                     variantAnnotation.setConsequenceTypes(consequenceTypeList);
                     if (phased) {
                         checkAndAdjustPhasedConsequenceTypes(variant, variantBuffer, dataRelease);

--- a/cellbase-lib/src/test/java/org/opencb/cellbase/lib/impl/core/VariantAnnotationCalculatorTest.java
+++ b/cellbase-lib/src/test/java/org/opencb/cellbase/lib/impl/core/VariantAnnotationCalculatorTest.java
@@ -33,6 +33,7 @@ import org.opencb.cellbase.core.result.CellBaseDataResult;
 import org.opencb.cellbase.lib.GenericMongoDBAdaptorTest;
 import org.opencb.cellbase.lib.variant.annotation.VariantAnnotationCalculator;
 import org.opencb.commons.datastore.core.QueryOptions;
+import org.opencb.commons.datastore.core.result.QueryResult;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -1955,6 +1956,39 @@ public class VariantAnnotationCalculatorTest extends GenericMongoDBAdaptorTest {
 //            }
 //            vepFileIndex++;
 //        }
+    }
+
+    @Test
+    // long variant should have same annotations as short variant + cnvPadding
+    public void testCNVExtraPadding() throws Exception {
+
+        // short variant
+        Variant shortVariant = new Variant("chr17:43087248-43087249:<CNV>");
+        // long variant
+        Variant longVariant = new Variant("chr17:43087248-43098506:<CNV>");
+
+        QueryOptions queryOptions = new QueryOptions("useCache", false);
+        queryOptions.put("include", "consequenceType, reference, alternate ,clinical");
+        queryOptions.put("normalize", true);
+        queryOptions.put("skipDecompose", false);
+        queryOptions.put("checkAminoAcidChange", true);
+        queryOptions.put("imprecise", true);
+        queryOptions.put("phased", false);
+
+        // long variant
+        CellBaseDataResult<ConsequenceType> consequenceTypeResult =
+                variantAnnotationCalculator.getAllConsequenceTypesByVariant(longVariant, queryOptions);
+        assertEquals(27, consequenceTypeResult.getNumResults());
+
+        // short variant
+        consequenceTypeResult = variantAnnotationCalculator.getAllConsequenceTypesByVariant(shortVariant, queryOptions);
+        assertEquals(27, consequenceTypeResult.getNumResults());
+
+        queryOptions.put("cnvExtraPadding", 10000);
+
+        // short variant with padding
+        consequenceTypeResult = variantAnnotationCalculator.getAllConsequenceTypesByVariant(shortVariant, queryOptions);
+        assertEquals(27, consequenceTypeResult.getNumResults());
     }
 
     private <T> void assertObjectListEquals(String expectedConsequenceTypeJson, List<T> actualList,


### PR DESCRIPTION
The CNV padding param currently has no effect. The query will be the same if you set it or not. This PR fixes the param to correctly pad the region queried. 

This was code reviewed by Javi and tested in v4. However the same test fails on v5. I think this is why.

Does this method need the data release version:

https://github.com/opencb/cellbase/blob/develop/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java#L1342

`        CellBaseDataResult<RegulatoryFeature> cellBaseDataResult = regulationManager.search(query);`

if so, how do I add? 