### PR TITLE
fix consequence types for CNVs with 2 copies

### DIFF
--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/variant/annotation/VariantAnnotationCalculator.java
@@ -1279,7 +1279,7 @@ public class VariantAnnotationCalculator {
             case CNV:
             case COPY_NUMBER_GAIN:
             case COPY_NUMBER:
-                if (variant.getSv().getCopyNumber() == null) {
+                if (variant.getSv().getCopyNumber() == null || variant.getSv().getCopyNumber() == 2) {
                     return new ConsequenceTypeGenericRegionCalculator();
                 } else if (variant.getSv().getCopyNumber() > 2) {
                     return new ConsequenceTypeCNVGainCalculator();


### PR DESCRIPTION
17:17465348-17695869:<CN2>++

Which would result in a transcript_ablation consequence in CellBase

This is wrong, the wrong consequence type calculator is selected - the deletion calculator. This PR fixes this issue and selects the correct consequence type calculator.

