### PR TITLE
fix long mnv for 1bp ref or alt

### DIFF
--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.4</version>
+        <version>4.12.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.4</version>
+        <version>4.12.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.4</version>
+        <version>4.12.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationUtils.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationUtils.java
@@ -674,7 +674,10 @@ public class VariantAnnotationUtils {
             } else {
                 return VariantType.MNV;
             }
-        } else if (!variant.isSymbolic() && variant.getReference().length() > 1 && variant.getAlternate().length() > 1) {
+        } else if (!variant.isSymbolic() && (variant.getReference().length() > 1 || variant.getAlternate().length() > 1)
+                &&
+                (!variant.getReference().startsWith(variant.getAlternate()) && !variant.getAlternate().startsWith(variant.getReference()))
+        ) {
             if (variant.getReference().length() <= MAX_MNV_THRESHOLD && variant.getAlternate().length() <= MAX_MNV_THRESHOLD) {
                 return VariantType.MNV;
             } else {

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.4</version>
+        <version>4.12.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-lib/src/test/java/org/opencb/cellbase/lib/impl/VariantAnnotationCalculatorTest.java
+++ b/cellbase-lib/src/test/java/org/opencb/cellbase/lib/impl/VariantAnnotationCalculatorTest.java
@@ -2401,6 +2401,24 @@ public class VariantAnnotationCalculatorTest extends GenericMongoDBAdaptorTest {
         assertFalse(consequenceTypeList.isEmpty());
         sequenceOntologyTerms = getSequenceOntologyTerms("ENST00000399839", consequenceTypeList);
         assertEquals("[{\"accession\": \"SO:0001906\", \"name\": \"feature_truncation\"}, {\"accession\": \"SO:0001627\", \"name\": \"intron_variant\"}]", sequenceOntologyTerms);
+
+        // MNV with ref length = 1
+        variant = new  Variant("22", 17668822, "T", "CTCTACTAAAAATACAAAAAATTAGCCAGGCGTGGTGGCAGGTGCCTGTAGTAC");
+        queryResult = variantAnnotationCalculator
+                .getAnnotationByVariant(variant, queryOptions);
+        consequenceTypeList  = queryResult.getResult().get(0).getConsequenceTypes();
+        assertFalse(consequenceTypeList.isEmpty());
+        sequenceOntologyTerms = getSequenceOntologyTerms("ENST00000399839", consequenceTypeList);
+        assertEquals("[{\"accession\": \"SO:0001627\", \"name\": \"intron_variant\"}]", sequenceOntologyTerms);
+
+        // MNV with alt length = 1
+        variant = new  Variant("22", 17668822, "TCTCTACTAAAAATACAAAAAATTAGCCAGGCGTGGTGGCAGGTGCCTGTAGTAC", "C");
+        queryResult = variantAnnotationCalculator
+                .getAnnotationByVariant(variant, queryOptions);
+        consequenceTypeList  = queryResult.getResult().get(0).getConsequenceTypes();
+        assertFalse(consequenceTypeList.isEmpty());
+        sequenceOntologyTerms = getSequenceOntologyTerms("ENST00000399839", consequenceTypeList);
+        assertEquals("[{\"accession\": \"SO:0001627\", \"name\": \"intron_variant\"}]", sequenceOntologyTerms);
     }
 
     @Test(expected = UnsupportedURLVariantFormat.class)

--- a/cellbase-lib/src/test/java/org/opencb/cellbase/lib/impl/VariantAnnotationCalculatorTest.java
+++ b/cellbase-lib/src/test/java/org/opencb/cellbase/lib/impl/VariantAnnotationCalculatorTest.java
@@ -2439,7 +2439,7 @@ public class VariantAnnotationCalculatorTest extends GenericMongoDBAdaptorTest {
 
     public String getSequenceOntologyTerms(String transcriptID, List<ConsequenceType> consequenceTypeList){
         for (ConsequenceType consequenceType : consequenceTypeList) {
-            if (consequenceType.getEnsemblTranscriptId().equals("ENST00000399839")){
+            if (consequenceType.getEnsemblTranscriptId().equals(transcriptID)){
                 return consequenceType.getSequenceOntologyTerms().toString();
             };
         }

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.4</version>
+        <version>4.12.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.12.4</version>
+    <version>4.12.5</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.12.4</version>
+    <version>4.12.5</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.12.4</cellbase.version>
+        <cellbase.version>4.12.5</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.6</biodata.version>


### PR DESCRIPTION
Variants such as `Variant("22", 17668822, "T", "CTCTACTAAAAATACAAAAAATTAGCCAGGCGTGGTGGCAGGTGCCTGTAGTAC")` are producing no consequence type. To fix, classify them as MNV to use the MNV conseq type calculator.