### PR TITLE
Fix decomposed mnv codon change

### DIFF
--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.5</version>
+        <version>4.12.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.5</version>
+        <version>4.12.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.5</version>
+        <version>4.12.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
@@ -675,7 +675,7 @@ public class VariantAnnotationCalculator {
                                             + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant1.getAlternate().toUpperCase().toCharArray()[0])
                                             + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant0.getAlternate().toUpperCase().toCharArray()[0]);
                         } else {
-                            alternateCodon = variant0.getAlternate() + variant1.getAlternate() + variant2.getAlternate();
+                            alternateCodon = variant0.getAlternate().toUpperCase() + variant1.getAlternate().toUpperCase() + variant2.getAlternate().toUpperCase();
                         }
 
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
@@ -652,9 +652,6 @@ public class VariantAnnotationCalculator {
                         = findCodingOverlappingConsequenceType(consequenceType1, variant1.getAnnotation().getConsequenceTypes());
                 // The two first variants affect the same codon
                 if (consequenceType2 != null) {
-                    // WARNING: assumes variants are sorted according to their coordinates
-                    int cdnaPosition = consequenceType1.getCdnaPosition();
-                    int cdsPosition = consequenceType1.getCdsPosition();
                     String codon = null;
                     String alternateAA = null;
                     List<SequenceOntologyTerm> soTerms = null;
@@ -673,10 +670,10 @@ public class VariantAnnotationCalculator {
                         String alternateCodon = null;
 
                         // negative strand
-                        if ("-".equals(variant0.getStrand())) {
-                            alternateCodon = "" + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant2.getAlternate())
-                                            + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant1.getAlternate())
-                                            + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant0.getAlternate());
+                        if ("-".equals(consequenceType1.getStrand())) {
+                            alternateCodon = "" + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant2.getAlternate().toUpperCase().toCharArray()[0])
+                                            + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant1.getAlternate().toUpperCase().toCharArray()[0])
+                                            + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant0.getAlternate().toUpperCase().toCharArray()[0]);
                         } else {
                             alternateCodon = variant0.getAlternate() + variant1.getAlternate() + variant2.getAlternate();
                         }
@@ -689,8 +686,6 @@ public class VariantAnnotationCalculator {
                                 variant1.getChromosome().equals("MT"));
 
                         // Update consequenceType3
-                        consequenceType3.setCdnaPosition(cdnaPosition);
-                        consequenceType3.setCdsPosition(cdsPosition);
                         consequenceType3.setCodon(codon);
                         consequenceType3.getProteinVariantAnnotation().setAlternate(alternateAA);
                         newProteinVariantAnnotation = getProteinAnnotation(consequenceType3);
@@ -716,7 +711,7 @@ public class VariantAnnotationCalculator {
                         char[] alternateCodonArray = referenceCodonArray.clone();
 
                         // negative strand
-                        if ("-".equals(variant0.getStrand())) {
+                        if ("-".equals(consequenceType1.getStrand())) {
                             alternateCodonArray[codonIdx1] =
                                     VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant0.getAlternate().toUpperCase().toCharArray()[0]);
                             alternateCodonArray[codonIdx2] =
@@ -739,8 +734,6 @@ public class VariantAnnotationCalculator {
                     consequenceType1.setProteinVariantAnnotation(newProteinVariantAnnotation == null
                             ? getProteinAnnotation(consequenceType1) : newProteinVariantAnnotation);
                     consequenceType1.setSequenceOntologyTerms(soTerms);
-                    consequenceType2.setCdnaPosition(cdnaPosition);
-                    consequenceType2.setCdsPosition(cdsPosition);
                     consequenceType2.setCodon(codon);
                     consequenceType2.getProteinVariantAnnotation().setAlternate(alternateAA);
                     consequenceType2.setProteinVariantAnnotation(consequenceType1.getProteinVariantAnnotation());

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.5</version>
+        <version>4.12.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.5</version>
+        <version>4.12.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.12.5</version>
+    <version>4.12.6</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.12.5</cellbase.version>
+        <cellbase.version>4.12.6</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.6</biodata.version>


### PR DESCRIPTION
Bug fix for negative strand codon changes which are being miscalculated. Example:
```
variant 12:44779924:AA:CC
no decompose:
12:44779924:AA:CC
strand: - cdsPosition: 430 TTG/GGG ENST00000395487
LEU => GLY
decompose:
12:44779924:A:C
strand: - cdsPosition: 431 TTg/CCg ENST00000395487
LEU => PRO
12:44779925:A:C
strand: - cdsPosition: 431 TTg/CCg ENST00000395487
LEU => PRO 
```
Decomposed variants should return similar codon and amino acid change as the original non-decomposed variant LEU => GLY. 
In this PR, this is fixed by correcting the if condition that checks if a variant is on a negative strand transcript.