### PR TITLE
Fix insertion with n consequence type

### DIFF
--- a/cellbase-app/pom.xml
+++ b/cellbase-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.6</version>
+        <version>4.12.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-client/pom.xml
+++ b/cellbase-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.6</version>
+        <version>4.12.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/pom.xml
+++ b/cellbase-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.6</version>
+        <version>4.12.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationCalculator.java
@@ -671,11 +671,14 @@ public class VariantAnnotationCalculator {
 
                         // negative strand
                         if ("-".equals(consequenceType1.getStrand())) {
-                            alternateCodon = "" + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant2.getAlternate().toUpperCase().toCharArray()[0])
-                                            + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant1.getAlternate().toUpperCase().toCharArray()[0])
-                                            + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant0.getAlternate().toUpperCase().toCharArray()[0]);
+                            alternateCodon = ""
+                                    + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant2.getAlternate().toUpperCase().toCharArray()[0])
+                                    + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant1.getAlternate().toUpperCase().toCharArray()[0])
+                                    + VariantAnnotationUtils.COMPLEMENTARY_NT.get(variant0.getAlternate().toUpperCase().toCharArray()[0]);
                         } else {
-                            alternateCodon = variant0.getAlternate().toUpperCase() + variant1.getAlternate().toUpperCase() + variant2.getAlternate().toUpperCase();
+                            alternateCodon = variant0.getAlternate().toUpperCase()
+                                    + variant1.getAlternate().toUpperCase()
+                                    + variant2.getAlternate().toUpperCase();
                         }
 
 

--- a/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationUtils.java
+++ b/cellbase-core/src/main/java/org/opencb/cellbase/core/variant/annotation/VariantAnnotationUtils.java
@@ -667,7 +667,12 @@ public class VariantAnnotationUtils {
         // FIXME: remove the if block below as soon as the Variant.inferType method is able to differentiate between
         // FIXME: insertions and deletions
 //        if (variant.getType().equals(VariantType.INDEL) || variant.getType().equals(VariantType.SV)) {
-        if (variant.getType().equals(VariantType.INDEL)) {
+        if (variant.getType().equals(VariantType.INDEL)
+                || (variant.getType().equals(VariantType.SV)
+                && !variant.isSymbolic()
+                && variant.getReference().length() <= MAX_MNV_THRESHOLD
+                && variant.getAlternate().length() <= MAX_MNV_THRESHOLD)
+        ) {
             if (variant.getReference().isEmpty()) {
 //                variant.setType(VariantType.INSERTION);
                 return VariantType.INSERTION;
@@ -676,15 +681,6 @@ public class VariantAnnotationUtils {
                 return VariantType.DELETION;
             } else {
                 return VariantType.MNV;
-            }
-        } else if (!variant.isSymbolic() && (variant.getReference().length() > 1 || variant.getAlternate().length() > 1)
-                &&
-                (!variant.getReference().startsWith(variant.getAlternate()) && !variant.getAlternate().startsWith(variant.getReference()))
-        ) {
-            if (variant.getReference().length() <= MAX_MNV_THRESHOLD && variant.getAlternate().length() <= MAX_MNV_THRESHOLD) {
-                return VariantType.MNV;
-            } else {
-                logger.warn("Provided alleles for variant are too long to be considered an MNV: %s", variant);
             }
         }
         return variant.getType();

--- a/cellbase-core/src/test/java/org/opencb/cellbase/core/variant/VariantAnnotationUtilsTest.java
+++ b/cellbase-core/src/test/java/org/opencb/cellbase/core/variant/VariantAnnotationUtilsTest.java
@@ -1,0 +1,42 @@
+package org.opencb.cellbase.core.variant;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.opencb.biodata.models.variant.Variant;
+import org.opencb.biodata.models.variant.avro.VariantType;
+import org.opencb.cellbase.core.variant.annotation.VariantAnnotationUtils;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Enclosed.class)
+public class VariantAnnotationUtilsTest {
+    @RunWith(Parameterized.class)
+    public static class GetVariantAnnotationTest {
+        private String variant;
+        private VariantType expectedVariantType;
+        public GetVariantAnnotationTest(String variant, VariantType expectedVariantType){
+            this.variant = variant;
+            this.expectedVariantType = expectedVariantType;
+        }
+        @Test
+        public void test() {
+            assertEquals(VariantAnnotationUtils.getVariantType(new Variant(variant)), expectedVariantType);
+        }
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][] {
+                    {"13:52718051:N:TGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGN", VariantType.INSERTION},
+                    {"13:52718051:C:TGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTG", VariantType.MNV},
+                    {"13:52718051:C:TGTGTG", VariantType.MNV},
+                    {"13:52718051:C:G", VariantType.SNV},
+                    {"13:52718051:C:", VariantType.DELETION},
+                    {"13:52718051::G", VariantType.INSERTION}
+            });
+        }
+    }
+}

--- a/cellbase-lib/pom.xml
+++ b/cellbase-lib/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.6</version>
+        <version>4.12.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-lib/src/test/java/org/opencb/cellbase/lib/impl/VariantAnnotationCalculatorTest.java
+++ b/cellbase-lib/src/test/java/org/opencb/cellbase/lib/impl/VariantAnnotationCalculatorTest.java
@@ -2512,14 +2512,14 @@ public class VariantAnnotationCalculatorTest extends GenericMongoDBAdaptorTest {
         sequenceOntologyTerms = getSequenceOntologyTerms("ENST00000399839", consequenceTypeList);
         assertEquals("[{\"accession\": \"SO:0001627\", \"name\": \"intron_variant\"}]", sequenceOntologyTerms);
 
-        // MNV with alt length = 1
+        // Deletion instead of MNV produces feature_truncation in addition to intron_variant
         variant = new  Variant("22", 17668822, "TCTCTACTAAAAATACAAAAAATTAGCCAGGCGTGGTGGCAGGTGCCTGTAGTAC", "C");
         queryResult = variantAnnotationCalculator
                 .getAnnotationByVariant(variant, queryOptions);
         consequenceTypeList  = queryResult.getResult().get(0).getConsequenceTypes();
         assertFalse(consequenceTypeList.isEmpty());
         sequenceOntologyTerms = getSequenceOntologyTerms("ENST00000399839", consequenceTypeList);
-        assertEquals("[{\"accession\": \"SO:0001627\", \"name\": \"intron_variant\"}]", sequenceOntologyTerms);
+        assertEquals("[{\"accession\": \"SO:0001906\", \"name\": \"feature_truncation\"}, {\"accession\": \"SO:0001627\", \"name\": \"intron_variant\"}]", sequenceOntologyTerms);
     }
 
     @Test(expected = UnsupportedURLVariantFormat.class)

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.opencb.cellbase</groupId>
         <artifactId>cellbase</artifactId>
-        <version>4.12.6</version>
+        <version>4.12.7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cellbase-test/pom.xml
+++ b/cellbase-test/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase-test</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>pom</packaging>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.opencb.cellbase</groupId>
     <artifactId>cellbase</artifactId>
-    <version>4.12.6</version>
+    <version>4.12.7</version>
     <packaging>pom</packaging>
 
     <name>CellBase project</name>
@@ -22,7 +22,7 @@
     </modules>
 
     <properties>
-        <cellbase.version>4.12.6</cellbase.version>
+        <cellbase.version>4.12.7</cellbase.version>
         <compileSource>1.8</compileSource>
         <java-common-libs.version>3.7.5</java-common-libs.version>
         <biodata.version>1.5.7</biodata.version>


### PR DESCRIPTION
4.12.5 introduced a bug where insertion variants > 50bp with N in the reference are classified as MNVs and therefore their consequeneTypes are miscalculated.

E.g of variant: 11:68410141:N:TGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGTGN
