### PR TITLE
TASK-4970 - New CI/CD should be triggered when a PR is approved for OpenCGA repository

### DIFF
--- a/.github/workflows/pull-request-approved.yml
+++ b/.github/workflows/pull-request-approved.yml
@@ -1,0 +1,15 @@
+name: Pull request approve workflow
+
+on:
+  pull_request_review:
+    types: [ submitted ]
+
+jobs:
+  build:
+    uses: opencb/java-common-libs/.github/workflows/build-java-app-workflow.yml@develop
+
+  test:
+    name: "Test analysis"
+    uses: ./.github/workflows/test-analysis.yml
+    needs: build
+    secrets: inherit


### PR DESCRIPTION
TASK-4970 - New CI/CD should be triggered when a PR is approved for OpenCGA repository