### PR TITLE
TASK-6880 - CI/CD workflow to delete task docker images on merge fails

### DIFF
--- a/.github/workflows/pull-request-merge.yml
+++ b/.github/workflows/pull-request-merge.yml
@@ -9,8 +9,9 @@ on:
       - closed
 
 jobs:
-  delete-docker:
-    uses: opencb/java-common-libs/.github/workflows/delete-docker-hub-workflow.yml@develop
+  call-delete-docker:
+    name: Call Reusable Delete Docker Workflow
+    uses: opencb/cellbase/.github/workflows/reusable-delete-docker.yml@develop
     with:
-      cli: python3 ./build/cloud/docker/docker-build.py delete --images base --tag ${{ github.head_ref }}
+      task: ${{ github.head_ref }}
     secrets: inherit


### PR DESCRIPTION
[TASK-6880 - CI/CD workflow to delete task docker images on merge fails](https://app.clickup.com/t/36631768/TASK-6880)