### PR TITLE
TASK-7463 Modify CellBase clinical variant builders

### DIFF
--- a/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/admin/executors/BuildCommandExecutor.java
+++ b/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/admin/executors/BuildCommandExecutor.java
@@ -367,7 +367,7 @@ public class BuildCommandExecutor extends CommandExecutor {
 
     private CellBaseBuilder buildClinicalVariants() {
         Path clinicalVariantFolder = downloadFolder.resolve(EtlCommons.CLINICAL_VARIANTS_FOLDER);
-        copyVersionFiles(Arrays.asList(clinicalVariantFolder.resolve("clinvarVersion.json")));
+        copyVersionFiles(Arrays.asList(clinicalVariantFolder.resolve(CLINVAR_VERSION_FILENAME)));
         copyVersionFiles(Arrays.asList(clinicalVariantFolder.resolve("gwasVersion.json")));
 
         CellBaseSerializer serializer = new CellBaseJsonFileSerializer(buildFolder,

--- a/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/admin/executors/LoadCommandExecutor.java
+++ b/cellbase-app/src/main/java/org/opencb/cellbase/app/cli/admin/executors/LoadCommandExecutor.java
@@ -484,7 +484,7 @@ public class LoadCommandExecutor extends CommandExecutor {
 
                 // Update release (collection and sources)
                 List<Path> sources = new ArrayList<>(Arrays.asList(
-                        input.resolve("clinvarVersion.json"),
+                        input.resolve(CLINVAR_VERSION_FILENAME),
                         input.resolve("cosmicVersion.json"),
                         input.resolve("gwasVersion.json")
                 ));

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/EtlCommons.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/EtlCommons.java
@@ -56,15 +56,18 @@ public class EtlCommons {
     public static final String PHARMGKB_VERSION_FILENAME = "pharmgkbVersion.json";
 
     public static final String CLINICAL_VARIANTS_FOLDER = "clinicalVariant";
-    public static final String CLINVAR_VERSION = "2024-05";
-    public static final String CLINVAR_DATE = "2024-05";
-    public static final String CLINVAR_XML_FILE = "ClinVarFullRelease_2024-05.xml.gz";
+    public static final String CLINVAR_XML_FILE = "ClinVarFullRelease.xml.gz";
     public static final String CLINVAR_EFO_FILE = "ClinVar_Traits_EFO_Names.csv";
     public static final String CLINVAR_SUMMARY_FILE = "variant_summary.txt.gz";
     public static final String CLINVAR_VARIATION_ALLELE_FILE = "variation_allele.txt.gz";
+    public static final String CLINVAR_VERSION_FILENAME = "clinvarVersion.json";
+
     public static final String IARCTP53_FILE = "IARC-TP53.zip";
     public static final String GWAS_FILE = "gwas_catalog.tsv";
     public static final String COSMIC_FILE = "CosmicMutantExport.tsv.gz";
+    public static final String COSMIC_VERSION_FILENAME = "cosmicVersion.json";
+    public static final String HGMD_VERSION_FILENAME = "hgmdVersion.json";
+
     @Deprecated
     public static final String DBSNP_FILE = "GCF_000001405.40.gz";
     public static final String DBSNP_NAME = "dbSNP";

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/ClinVarIndexer.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/ClinVarIndexer.java
@@ -17,10 +17,13 @@
 package org.opencb.cellbase.lib.builders.clinical.variant;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.commons.lang3.StringUtils;
 import org.opencb.biodata.formats.variant.clinvar.rcv.ClinvarParser;
 import org.opencb.biodata.formats.variant.clinvar.rcv.v64jaxb.*;
 import org.opencb.biodata.models.variant.avro.*;
+import org.opencb.cellbase.core.models.DataReleaseSource;
 import org.opencb.cellbase.lib.EtlCommons;
 import org.opencb.cellbase.lib.variant.VariantAnnotationUtils;
 import org.opencb.commons.ProgressLogger;
@@ -41,8 +44,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.opencb.cellbase.lib.EtlCommons.CLINVAR_DATE;
-import static org.opencb.cellbase.lib.EtlCommons.CLINVAR_VERSION;
+import static org.opencb.cellbase.lib.EtlCommons.*;
 
 //import org.opencb.biodata.formats.variant.clinvar.v24jaxb.*;
 
@@ -83,6 +85,10 @@ public class ClinVarIndexer extends ClinicalIndexer {
     private final Path clinvarVariationAlleleFile;
     private final Path clinvarEFOFile;
     private final String assembly;
+
+    private String version;
+    private String date;
+
     private int numberSomaticRecords = 0;
     private int numberGermlineRecords = 0;
     private int numberNoDiseaseTrait = 0;
@@ -98,7 +104,7 @@ public class ClinVarIndexer extends ClinicalIndexer {
                           Path clinvarEFOFile, boolean normalize, Path genomeSequenceFilePath, String assembly,
                           RocksDB rdb) throws IOException {
         super(genomeSequenceFilePath);
-        this.rdb = rdb;
+
         this.clinvarXMLFiles = clinvarXMLFiles;
         this.clinvarSummaryFile = clinvarSummaryFile;
         this.clinvarVariationAlleleFile = clinvarVariationAlleleFile;
@@ -106,10 +112,24 @@ public class ClinVarIndexer extends ClinicalIndexer {
         this.normalize = normalize;
         this.genomeSequenceFilePath = genomeSequenceFilePath;
         this.assembly = assembly;
+
+        this.rdb = rdb;
     }
 
     public void index() throws RocksDBException {
         try {
+            Path clinvarVersionPath = clinvarSummaryFile.getParent().resolve(CLINVAR_VERSION_FILENAME);
+            if (!Files.exists(clinvarVersionPath)) {
+                throw new IOException("ClinVar version file " + clinvarVersionPath + " does not exist");
+            }
+            ObjectMapper jsonObjectMapper = new ObjectMapper();
+            ObjectReader jsonObjectReader = jsonObjectMapper.readerFor(DataReleaseSource.class);
+            DataReleaseSource dataReleaseSource = jsonObjectReader.readValue(clinvarVersionPath.toFile());
+
+            this.date = dataReleaseSource.getDate();
+            this.version = dataReleaseSource.getVersion();
+
+
             Map<String, EFO> traitsToEfoTermsMap = loadEFOTerms();
             Map<String, List<AlleleLocationData>> rcvToAlleleLocationData = parseVariantSummary(traitsToEfoTermsMap);
 
@@ -156,15 +176,9 @@ public class ClinVarIndexer extends ClinicalIndexer {
             }
             logger.info("Done");
             printSummary();
-        } catch (RocksDBException e) {
-            logger.error("Error reading/writing from/to the RocksDB index while indexing ClinVar");
-            throw e;
-        } catch (JAXBException e) {
-            logger.error("Error unmarshalling clinvar Xml file: " + e.getMessage());
-            e.printStackTrace();
-        } catch (IOException e) {
-            logger.error("Error indexing clinvar Xml file: " + e.getMessage());
-            e.printStackTrace();
+        } catch (RocksDBException | JAXBException | IOException e) {
+            logger.error("Error indexing ClinVar", e);
+            throw new RocksDBException(e.getMessage());
         }
     }
 
@@ -331,7 +345,7 @@ public class ClinVarIndexer extends ClinicalIndexer {
                                String mateVariantString, String clinicalHaplotypeString,
                                Map<String, EFO> traitsToEfoTermsMap) {
 
-        EvidenceSource evidenceSource = new EvidenceSource(EtlCommons.CLINVAR_DATA, CLINVAR_VERSION, CLINVAR_DATE);
+        EvidenceSource evidenceSource = new EvidenceSource(EtlCommons.CLINVAR_DATA, version, date);
         // Create a set to avoid situations like germline;germline;germline
         List<AlleleOrigin> alleleOrigin = null;
         if (!EtlCommons.isMissing(lineFields[VARIANT_SUMMARY_ORIGIN_COLUMN])) {
@@ -412,7 +426,7 @@ public class ClinVarIndexer extends ClinicalIndexer {
             throws JsonProcessingException {
 
         List<Property> additionalProperties = new ArrayList<>(3);
-        EvidenceSource evidenceSource = new EvidenceSource(EtlCommons.CLINVAR_DATA, CLINVAR_VERSION, CLINVAR_DATE);
+        EvidenceSource evidenceSource = new EvidenceSource(EtlCommons.CLINVAR_DATA, version, date);
 //        String accession = publicSet.getReferenceClinVarAssertion().getClinVarAccession().getAcc();
 
         VariantClassification variantClassification = getVariantClassification(

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/ClinicalVariantBuilder.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/ClinicalVariantBuilder.java
@@ -22,13 +22,13 @@ import org.opencb.biodata.models.variant.avro.VariantAnnotation;
 import org.opencb.cellbase.core.serializer.CellBaseSerializer;
 import org.opencb.cellbase.lib.EtlCommons;
 import org.opencb.cellbase.lib.builders.CellBaseBuilder;
+import org.opencb.commons.utils.FileUtils;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -124,8 +124,17 @@ public class ClinicalVariantBuilder extends CellBaseBuilder {
             if (this.clinvarXMLFile != null && this.clinvarSummaryFile != null
                     && this.clinvarVariationAlleleFile != null && Files.exists(clinvarXMLFile)
                     && Files.exists(clinvarSummaryFile) && Files.exists(clinvarVariationAlleleFile)) {
-              ClinVarIndexer clinvarIndexer = new ClinVarIndexer(clinvarXMLFile.getParent().resolve("clinvar_chunks"), clinvarSummaryFile,
-                        clinvarVariationAlleleFile, clinvarEFOFile, normalize, genomeSequenceFilePath, assembly, rdb);
+
+                Path chunksPaths = clinvarXMLFile.getParent().resolve("clinvar_chunks");
+                if (Files.notExists(chunksPaths)) {
+                    logger.info("Splitting ClinVar XML file in multiple ClinVar chunk files at {} ...", chunksPaths);
+                    Files.createDirectories(chunksPaths);
+                    splitClinvar(this.clinvarXMLFile, chunksPaths);
+                    logger.info("Done");
+                }
+
+              ClinVarIndexer clinvarIndexer = new ClinVarIndexer(chunksPaths, clinvarSummaryFile, clinvarVariationAlleleFile,
+                      clinvarEFOFile, normalize, genomeSequenceFilePath, assembly, rdb);
                 clinvarIndexer.index();
             } else {
                 logger.warn("One or more of required ClinVar files are missing. Skipping ClinVar data.\n"
@@ -187,6 +196,48 @@ public class ClinicalVariantBuilder extends CellBaseBuilder {
             throw e;
         }
 
+    }
+
+    private void splitClinvar(Path clinvarXmlFilePath, Path splitOutdirPath) throws IOException {
+        BufferedReader br = FileUtils.newBufferedReader(clinvarXmlFilePath);
+        PrintWriter pw = null;
+        StringBuilder header = new StringBuilder();
+        boolean beforeEntry = true;
+        boolean inEntry = false;
+        int count = 0;
+        int chunk = 0;
+        String line;
+        while ((line = br.readLine()) != null) {
+            if (line.trim().startsWith("<ClinVarSet ")) {
+                inEntry = true;
+                beforeEntry = false;
+                if (count % 10000 == 0) {
+                    pw = new PrintWriter(new FileOutputStream(splitOutdirPath.resolve("chunk_" + chunk + ".xml").toFile()));
+                    pw.println(header.toString().trim());
+                }
+                count++;
+            }
+
+            if (beforeEntry) {
+                header.append(line).append("\n");
+            }
+
+            if (inEntry) {
+                pw.println(line);
+            }
+
+            if (line.trim().startsWith("</ClinVarSet>")) {
+                inEntry = false;
+                if (count % 10000 == 0) {
+                    pw.print("</ReleaseSet>");
+                    pw.close();
+                    chunk++;
+                }
+            }
+        }
+        pw.print("</ReleaseSet>");
+        pw.close();
+        br.close();
     }
 
     private void serializeRDB(RocksDB rdb) throws IOException {

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/CosmicIndexer.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/CosmicIndexer.java
@@ -16,8 +16,11 @@
 
 package org.opencb.cellbase.lib.builders.clinical.variant;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.commons.lang3.StringUtils;
 import org.opencb.biodata.models.variant.avro.*;
+import org.opencb.cellbase.core.models.DataReleaseSource;
 import org.opencb.cellbase.lib.EtlCommons;
 import org.opencb.cellbase.lib.variant.VariantAnnotationUtils;
 import org.opencb.commons.ProgressLogger;
@@ -27,11 +30,14 @@ import org.rocksdb.RocksDBException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.opencb.cellbase.lib.EtlCommons.COSMIC_VERSION_FILENAME;
 
 
 public class CosmicIndexer extends ClinicalIndexer {
@@ -40,8 +46,6 @@ public class CosmicIndexer extends ClinicalIndexer {
     private final String assembly;
     private Pattern mutationGRCh37GenomePositionPattern;
     private Pattern snvPattern;
-
-    private static final String COSMIC_VERSION = "v99";
 
     private static final int GENE_NAMES_COLUMN = 0;
     private static final int HGNC_COLUMN = 3;
@@ -79,6 +83,9 @@ public class CosmicIndexer extends ClinicalIndexer {
 
     private static final String VARIANT_STRING_PATTERN = "[ACGT]*";
 
+    private String date;
+    private String version;
+
     private int ignoredCosmicLines = 0;
     private long normaliseTime = 0;
     private int rocksDBNewVariants = 0;
@@ -101,9 +108,20 @@ public class CosmicIndexer extends ClinicalIndexer {
     }
 
     public void index() throws RocksDBException {
-        logger.info("Parsing cosmic file ...");
-
         try {
+            Path cosmicVersionPath = cosmicFile.getParent().resolve(COSMIC_VERSION_FILENAME);
+            if (!Files.exists(cosmicVersionPath)) {
+                throw new IOException("COSMIC version file " + cosmicVersionPath + " does not exist");
+            }
+            ObjectMapper jsonObjectMapper = new ObjectMapper();
+            ObjectReader jsonObjectReader = jsonObjectMapper.readerFor(DataReleaseSource.class);
+            DataReleaseSource dataReleaseSource = jsonObjectReader.readValue(cosmicVersionPath.toFile());
+
+            this.date = dataReleaseSource.getDate();
+            this.version = dataReleaseSource.getVersion();
+
+            logger.info("Parsing cosmic file ...");
+
             ProgressLogger progressLogger = new ProgressLogger("Parsed COSMIC lines:",
                     () -> EtlCommons.countFileLines(cosmicFile), 200).setBatchSize(10000);
 
@@ -168,11 +186,9 @@ public class CosmicIndexer extends ClinicalIndexer {
                     rocksDBUpdateVariants = numberVariantUpdates;
                 }
             }
-        } catch (RocksDBException e) {
-            logger.error("Error reading/writing from/to the RocksDB index while indexing Cosmic");
-            throw e;
-        } catch (IOException ex) {
-            ex.printStackTrace();
+        } catch (RocksDBException | IOException e) {
+            logger.error("Error indexing Cosmic", e);
+            throw new RocksDBException(e.getMessage());
         } finally {
             logger.info("Done");
             this.printSummary();
@@ -469,7 +485,7 @@ public class CosmicIndexer extends ClinicalIndexer {
         String id = fields[ID_COLUMN];
         String url = "https://cancer.sanger.ac.uk/cosmic/search?q=" + id;
 
-        EvidenceSource evidenceSource = new EvidenceSource(EtlCommons.COSMIC_DATA, COSMIC_VERSION, null);
+        EvidenceSource evidenceSource = new EvidenceSource(EtlCommons.COSMIC_DATA, version, date);
         SomaticInformation somaticInformation = getSomaticInformation(fields);
         List<GenomicFeature> genomicFeatureList = getGenomicFeature(fields);
 

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/HGMDIndexer.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/builders/clinical/variant/HGMDIndexer.java
@@ -16,6 +16,8 @@
 
 package org.opencb.cellbase.lib.builders.clinical.variant;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.opencb.biodata.models.variant.Variant;
@@ -23,13 +25,17 @@ import org.opencb.biodata.models.variant.VariantFileMetadata;
 import org.opencb.biodata.models.variant.avro.*;
 import org.opencb.biodata.models.variant.metadata.VariantStudyMetadata;
 import org.opencb.biodata.tools.variant.VariantVcfHtsjdkReader;
+import org.opencb.cellbase.core.models.DataReleaseSource;
 import org.opencb.cellbase.lib.EtlCommons;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+
+import static org.opencb.cellbase.lib.EtlCommons.HGMD_VERSION_FILENAME;
 
 /**
  * Created by jtarraga on 23/02/22.
@@ -37,6 +43,9 @@ import java.util.*;
 public class HGMDIndexer extends ClinicalIndexer {
     private final Path hgmdFile;
     private final String assembly;
+
+    private String date;
+    private String version;
 
     public HGMDIndexer(Path hgmdFile, boolean normalize, Path genomeSequenceFilePath, String assembly, RocksDB rdb)
             throws IOException {
@@ -51,6 +60,18 @@ public class HGMDIndexer extends ClinicalIndexer {
         logger.info("Parsing HGMD file ...");
 
         try {
+
+            Path hgmdVersionPath = hgmdFile.getParent().resolve(HGMD_VERSION_FILENAME);
+            if (!Files.exists(hgmdVersionPath)) {
+                throw new IOException("HGMD version file " + hgmdVersionPath + " does not exist");
+            }
+            ObjectMapper jsonObjectMapper = new ObjectMapper();
+            ObjectReader jsonObjectReader = jsonObjectMapper.readerFor(DataReleaseSource.class);
+            DataReleaseSource dataReleaseSource = jsonObjectReader.readValue(hgmdVersionPath.toFile());
+
+            this.date = dataReleaseSource.getDate();
+            this.version = dataReleaseSource.getVersion();
+
             VariantStudyMetadata metadata = new VariantFileMetadata(null, hgmdFile.toString()).toVariantStudyMetadata("study");
             VariantVcfHtsjdkReader reader = new VariantVcfHtsjdkReader(hgmdFile.toAbsolutePath(), metadata);
             for (Variant variant : reader) {
@@ -74,7 +95,6 @@ public class HGMDIndexer extends ClinicalIndexer {
             throw e;
         } finally {
             logger.info("Done");
-
 //            this.printSummary();
         }
     }
@@ -93,7 +113,7 @@ public class HGMDIndexer extends ClinicalIndexer {
             }
 
             // Source
-            entry.setSource(new EvidenceSource(EtlCommons.HGMD_DATA, "2020.3", "2020"));
+            entry.setSource(new EvidenceSource(EtlCommons.HGMD_DATA, version, date));
 
             // Assembly
             entry.setAssembly(assembly);

--- a/cellbase-lib/src/main/java/org/opencb/cellbase/lib/download/ClinicalDownloadManager.java
+++ b/cellbase-lib/src/main/java/org/opencb/cellbase/lib/download/ClinicalDownloadManager.java
@@ -20,12 +20,12 @@ import org.opencb.cellbase.core.config.CellBaseConfiguration;
 import org.opencb.cellbase.core.config.DownloadProperties;
 import org.opencb.cellbase.core.exception.CellBaseException;
 import org.opencb.cellbase.lib.EtlCommons;
-import org.opencb.commons.utils.FileUtils;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,6 +33,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+
+import static org.opencb.cellbase.lib.EtlCommons.CLINVAR_VERSION_FILENAME;
 
 public class ClinicalDownloadManager extends AbstractDownloadManager {
 
@@ -82,7 +84,7 @@ public class ClinicalDownloadManager extends AbstractDownloadManager {
             downloadFiles.add(downloadFile(url, clinicalFolder.resolve(EtlCommons.CLINVAR_VARIATION_ALLELE_FILE).toString()));
             clinvarUrls.add(url);
             saveVersionData(EtlCommons.CLINICAL_VARIANTS_DATA, CLINVAR_NAME, configuration.getDownload().getClinvar()
-                            .getVersion(), getTimeStamp(), clinvarUrls, clinicalFolder.resolve("clinvarVersion.json"));
+                            .getVersion(), getTimeStamp(), clinvarUrls, clinicalFolder.resolve(CLINVAR_VERSION_FILENAME));
 
             logger.info("\t\tDone");
 
@@ -137,56 +139,9 @@ public class ClinicalDownloadManager extends AbstractDownloadManager {
 //                        Collections.singletonList(url), clinicalFolder.resolve("iarctp53Version.json"));
 //            }
 
-            if (Files.notExists(clinicalFolder.resolve("clinvar_chunks"))) {
-                Files.createDirectories(clinicalFolder.resolve("clinvar_chunks"));
-                splitClinvar(clinicalFolder.resolve(EtlCommons.CLINVAR_XML_FILE), clinicalFolder.resolve("clinvar_chunks"));
-            }
-
             return downloadFiles;
         }
         return null;
-    }
-
-    private void splitClinvar(Path clinvarXmlFilePath, Path splitOutdirPath) throws IOException {
-        BufferedReader br = FileUtils.newBufferedReader(clinvarXmlFilePath);
-        PrintWriter pw = null;
-        StringBuilder header = new StringBuilder();
-        boolean beforeEntry = true;
-        boolean inEntry = false;
-        int count = 0;
-        int chunk = 0;
-        String line;
-        while ((line = br.readLine()) != null) {
-            if (line.trim().startsWith("<ClinVarSet ")) {
-                inEntry = true;
-                beforeEntry = false;
-                if (count % 10000 == 0) {
-                    pw = new PrintWriter(new FileOutputStream(splitOutdirPath.resolve("chunk_" + chunk + ".xml").toFile()));
-                    pw.println(header.toString().trim());
-                }
-                count++;
-            }
-
-            if (beforeEntry) {
-                header.append(line).append("\n");
-            }
-
-            if (inEntry) {
-                pw.println(line);
-            }
-
-            if (line.trim().startsWith("</ClinVarSet>")) {
-                inEntry = false;
-                if (count % 10000 == 0) {
-                    pw.print("</ReleaseSet>");
-                    pw.close();
-                    chunk++;
-                }
-            }
-        }
-        pw.print("</ReleaseSet>");
-        pw.close();
-        br.close();
     }
 
     private String getDocmVersion(Path docmIndexHtml) {

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>cellbase-server</artifactId>
-    <packaging>jar</packaging>
+    <packaging>war</packaging>
 
     <dependencies>
         <dependency>

--- a/cellbase-server/pom.xml
+++ b/cellbase-server/pom.xml
@@ -137,15 +137,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.2.3</version>
-                <executions>
-                    <execution>
-                        <id>make-a-war</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>war</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <warName>${CELLBASE.WAR.NAME}</warName>
                     <webResources>
@@ -159,10 +150,26 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-<!--                <version>3.1.1</version>-->
+                <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>make-a-jar</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Plugin to install the JAR -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.1</version>
+                <executions>
+                    <execution>
+                        <id>install-jar</id>
                         <phase>install</phase>
                         <goals>
                             <goal>install-file</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <pycellbase.version>${project.version}</pycellbase.version>
         <java-common-libs.version>4.12.1-SNAPSHOT</java-common-libs.version>
-        <biodata.version>2.12.4-SNAPSHOT</biodata.version>
+        <biodata.version>2.12.3</biodata.version>
         <bionetdb.version>0.1.0</bionetdb.version>
         <jackson.version>2.11.4</jackson.version>
         <jackson-asl.version>1.9.13</jackson-asl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <pycellbase.version>${project.version}</pycellbase.version>
         <java-common-libs.version>4.12.1-SNAPSHOT</java-common-libs.version>
-        <biodata.version>2.12.3-SNAPSHOT</biodata.version>
+        <biodata.version>2.12.4-SNAPSHOT</biodata.version>
         <bionetdb.version>0.1.0</bionetdb.version>
         <jackson.version>2.11.4</jackson.version>
         <jackson-asl.version>1.9.13</jackson-asl.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <properties>
         <pycellbase.version>${project.version}</pycellbase.version>
         <java-common-libs.version>4.12.1-SNAPSHOT</java-common-libs.version>
-        <biodata.version>2.12.3</biodata.version>
+        <biodata.version>2.12.4-SNAPSHOT</biodata.version>
         <bionetdb.version>0.1.0</bionetdb.version>
         <jackson.version>2.11.4</jackson.version>
         <jackson-asl.version>1.9.13</jackson-asl.version>


### PR DESCRIPTION
Clinical variant builders currently have source versions, such as the ClinVar version, hardcoded in the code. Instead, these builders should retrieve versions from JSON version files created from the configuration.yml file. For example, for the ClinVar data source, the ClinVar builder should use the JSON file clinvarVersion.json.

[TASK-7463](https://app.clickup.com/t/86988btct)